### PR TITLE
Change description method calls to definition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'alchemy_cms', github: 'AlchemyCMS/alchemy_cms', branch: 'master'
+
 group :test do
   gem 'factory_girl_rails'
   gem "capybara"

--- a/lib/alchemy/pg_search/content_extension.rb
+++ b/lib/alchemy/pg_search/content_extension.rb
@@ -7,10 +7,10 @@ Alchemy::Content.class_eval do
   #
   def prepared_attributes_for_essence
     attributes = {
-      ingredient: default_text(description['default'])
+      ingredient: default_text(definition['default'])
     }
-    if Alchemy::PgSearch.is_searchable_essence?(description['type'])
-      attributes.merge!(searchable: description.fetch('searchable', true))
+    if Alchemy::PgSearch.is_searchable_essence?(definition['type'])
+      attributes.merge!(searchable: definition.fetch('searchable', true))
     end
     attributes
   end

--- a/lib/alchemy/pg_search/searchable.rb
+++ b/lib/alchemy/pg_search/searchable.rb
@@ -1,7 +1,7 @@
 module Alchemy
   module PgSearch
 
-    # Ensures that the current content description value for +searchable+ gets persisted.
+    # Ensures that the current content definition value for +searchable+ gets persisted.
     #
     # It is enabled per default, but you can disable indexing in your +elements.yml+ file.
     #
@@ -18,7 +18,7 @@ module Alchemy
 
       included do
         before_update do
-          write_attribute(:searchable, description.fetch('searchable', true))
+          write_attribute(:searchable, definition.fetch('searchable', true))
           true
         end
       end

--- a/spec/shared/persisted_searchable.rb
+++ b/spec/shared/persisted_searchable.rb
@@ -3,14 +3,14 @@ shared_examples_for 'persisted searchable' do
 
   describe '.after_update' do
     it "updates the value for `searchable`" do
-      allow(essence).to receive(:description).and_return({'searchable' => false})
+      allow(essence).to receive(:definition).and_return({'searchable' => false})
       essence.update!(searchable_column => 'hello')
       expect(essence.searchable).to be(false)
     end
 
     context "with `searchable` not set" do
       it "updates the value to true" do
-        allow(essence).to receive(:description).and_return({})
+        allow(essence).to receive(:definition).and_return({})
         essence.update!(searchable_column => 'hello')
         expect(essence.searchable).to be(true)
       end


### PR DESCRIPTION
Since Alchemy renamed all `description` method names to `definition` we need to do here, too.
