### PR TITLE
Configurable pagination

### DIFF
--- a/app/views/alchemy/search/_results.html.erb
+++ b/app/views/alchemy/search/_results.html.erb
@@ -6,7 +6,8 @@
   <% else %>
     <h2 class="search_results_heading">
       <%= raw Alchemy.t("search_result_page.result_heading", query: h(params[:query])) %>
-      <%= Alchemy.t("search_result_page.result_count", count: @search_results.length) %>
+      <%= Alchemy.t("search_result_page.result_count",
+        count: @search_results.try(:total_count) || @search_results.size) %>
     </h2>
     <ul class="search_result_list">
       <% @search_results.each do |page| %>
@@ -20,6 +21,6 @@
   <% end %>
 </div>
 
-<% if @search_results %>
+<% if @search_results.try(:total_pages) %>
   <%= paginate @search_results %>
 <% end %>

--- a/lib/alchemy-pg_search.rb
+++ b/lib/alchemy-pg_search.rb
@@ -1,8 +1,11 @@
 require "alchemy/pg_search/engine"
+require "alchemy/pg_search/config"
 
 module Alchemy
   module PgSearch
     SEARCHABLE_ESSENCES = %w(EssenceText EssenceRichtext EssencePicture)
+
+    extend Config
 
     def self.is_searchable_essence?(essence_type)
       SEARCHABLE_ESSENCES.include?(essence_type)

--- a/lib/alchemy/pg_search/config.rb
+++ b/lib/alchemy/pg_search/config.rb
@@ -1,0 +1,17 @@
+module Alchemy
+  module PgSearch
+    module Config
+      @@config = {
+        paginate_per: 10
+      }
+
+      def config=(settings)
+        @@config.merge!(settings)
+      end
+
+      def config
+        @@config
+      end
+    end
+  end
+end

--- a/lib/alchemy/pg_search/controller_methods.rb
+++ b/lib/alchemy/pg_search/controller_methods.rb
@@ -39,7 +39,9 @@ module Alchemy
         end
         return if params[:query].blank?
         @search_results = search_results
-        @search_results = @search_results.page(params[:page]).per(10)
+        if paginate_per
+          @search_results = @search_results.page(params[:page]).per(paginate_per)
+        end
       end
 
       # Find Pages that have what is provided in "query" param with PgSearch
@@ -80,6 +82,10 @@ module Alchemy
           raise "No searchresults page layout found. Please add page layout with `searchresults: true` into your `page_layouts.yml` file."
         end
         page_layout
+      end
+
+      def paginate_per
+        Alchemy::PgSearch.config[:paginate_per]
       end
     end
   end

--- a/spec/features/fulltext_search_feature_spec.rb
+++ b/spec/features/fulltext_search_feature_spec.rb
@@ -133,5 +133,47 @@ module Alchemy
         end
       end
     end
+
+    describe "pagination" do
+      before do
+        12.times do
+          create :alchemy_element,
+            page: create(:alchemy_page, :public, visible: true),
+            create_contents_after_create: true
+        end
+      end
+
+      context "when default config is used" do
+        it "displays 10 results per page" do
+          visit('/suche?query=text%20block')
+
+          within '.search_results_heading' do
+            expect(page).to have_text('12 Treffer')
+          end
+          within '.search_result_list' do
+            expect(page).to have_text('text block', count: 10)
+          end
+        end
+      end
+
+      context "when disabled per config" do
+        before do
+          Alchemy::PgSearch.config = {
+            paginate_per: nil
+          }
+        end
+
+        it "displays all results on one page" do
+          visit('/suche?query=text%20block')
+
+          within '.search_results_heading' do
+            expect(page).to have_text('12 Treffer')
+          end
+          within '.search_result_list' do
+            expect(page).to have_text('text block', count: 12)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The search results are paginated by 10 per page.

This uses the new config module to let this be configured by:

    Alchemy::PgSearch.config = {
      paginate_per: 20
    }

or even completely disabled with:

    Alchemy::PgSearch.config = {
      paginate_per: nil
    }