### PR TITLE
Search scope class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.0.0
-  - 2.1
-  - 2.2
+  - 2.3
+  - 2.4
 branches:
   only:
     - master

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,9 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'alchemy_cms', github: 'AlchemyCMS/alchemy_cms', branch: 'master'
+gem 'alchemy_cms', github: 'AlchemyCMS/alchemy_cms', branch: '3.6-stable'
 gem 'sassc-rails'
+gem 'pg', '< 1.0'
 
 group :test do
   gem 'factory_girl_rails'

--- a/lib/alchemy-pg_search.rb
+++ b/lib/alchemy-pg_search.rb
@@ -1,11 +1,16 @@
 require "alchemy/pg_search/engine"
 require "alchemy/pg_search/config"
+require "alchemy/pg_search/page_search_scope"
 
 module Alchemy
   module PgSearch
     SEARCHABLE_ESSENCES = %w(EssenceText EssenceRichtext EssencePicture)
+    DEFAULT_CONFIG = {
+      page_search_scope: PageSearchScope.new
+    }
 
     extend Config
+    self.config = DEFAULT_CONFIG
 
     def self.is_searchable_essence?(essence_type)
       SEARCHABLE_ESSENCES.include?(essence_type)

--- a/lib/alchemy/pg_search/controller_methods.rb
+++ b/lib/alchemy/pg_search/controller_methods.rb
@@ -49,7 +49,7 @@ module Alchemy
       # @return [Array]
       #
       def search_results
-        pages = Page.published.contentpages.with_language(Language.current.id)
+        pages = Alchemy::PgSearch.config[:page_search_scope].pages
         # Since CanCan cannot (oh the irony) merge +accessible_by+ scope with pg_search scopes,
         # we need to fake a page object here
         if can? :show, Alchemy::Page.new(restricted: true, public_on: Date.current)

--- a/lib/alchemy/pg_search/page_search_scope.rb
+++ b/lib/alchemy/pg_search/page_search_scope.rb
@@ -1,0 +1,9 @@
+module Alchemy
+  module PgSearch
+    class PageSearchScope
+      def pages
+        Alchemy::Page.published.contentpages.with_language(Alchemy::Language.current.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This class returns the scope of pages that the search is made on.

You can set your own page search scope class that respond to `#pages` in the config

```rb
Alchemy::PgSearch.config = {page_search_scope: MyPageSearchScope.new}
```
