### PR TITLE
Rename the #search method into #full_text_search

### DIFF
--- a/lib/alchemy/pg_search/controller_methods.rb
+++ b/lib/alchemy/pg_search/controller_methods.rb
@@ -53,9 +53,9 @@ module Alchemy
         # Since CanCan cannot (oh the irony) merge +accessible_by+ scope with pg_search scopes,
         # we need to fake a page object here
         if can? :show, Alchemy::Page.new(restricted: true, public_on: Date.current)
-          pages.search(params[:query])
+          pages.full_text_search(params[:query])
         else
-          pages.not_restricted.search(params[:query])
+          pages.not_restricted.full_text_search(params[:query])
         end
       end
 

--- a/lib/alchemy/pg_search/element_extension.rb
+++ b/lib/alchemy/pg_search/element_extension.rb
@@ -1,7 +1,7 @@
 Alchemy::Element.class_eval do
   include PgSearch
 
-  pg_search_scope :search,
+  pg_search_scope :full_text_search,
     associated_against: {
       searchable_essence_texts:     :body,
       searchable_essence_richtexts: :stripped_body,

--- a/lib/alchemy/pg_search/page_extension.rb
+++ b/lib/alchemy/pg_search/page_extension.rb
@@ -3,7 +3,7 @@ Alchemy::Page.class_eval do
 
   # Enable Postgresql full text indexing.
   #
-  pg_search_scope :search, against: {
+  pg_search_scope :full_text_search, against: {
       meta_description: 'B',
       meta_keywords:    'B',
       title:            'B',
@@ -40,6 +40,6 @@ Alchemy::Page.class_eval do
     source: :essence
 
   def element_search_results(query)
-    descendent_elements.search(query)
+    descendent_elements.full_text_search(query)
   end
 end


### PR DESCRIPTION
This avoids conflicts with Ransack that also defines a `#seach` method
on active record objects.

Since we are only using this method in our own controller and model extensions
this is considered not breaking.

Closes #1