### PR TITLE
Alchemy 4.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,9 @@ source "https://rubygems.org"
 gemspec
 
 gem "rails", "~> 5.1.0"
-gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: "4.0-stable"
+ENV.fetch("ALCHEMY_BRANCH", "4.3-stable").tap do |branch|
+  gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: branch
+end
 gem "sassc-rails"
 gem "sassc", "< 2.2.0"
 gem "pg", "< 1.0"

--- a/alchemy-pg_search.gemspec
+++ b/alchemy-pg_search.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "alchemy_cms", [">= 4.0", "< 4.3"]
+  spec.add_runtime_dependency "alchemy_cms", [">= 4.3", "< 5.0"]
   spec.add_runtime_dependency "pg_search", ["~> 2.1"]
   spec.add_runtime_dependency "pg"
 

--- a/lib/alchemy/pg_search/content_extension.rb
+++ b/lib/alchemy/pg_search/content_extension.rb
@@ -1,7 +1,8 @@
 module Alchemy::PgSearch::ContentExtension
   module ClassMethods
-    def build(element, essence_hash)
-      definition = content_definition(element, essence_hash)
+    def new(attributes)
+      element = attributes[:element]
+      definition = element.content_definition_for(attributes[:name])
       super.tap do |content|
         content.searchable = definition.key?(:searchable) ? definition[:searchable] : true
       end

--- a/spec/dummy/app/views/alchemy/elements/_article_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_article_view.html.erb
@@ -1,5 +1,5 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element) do |el| -%>
+<%- cache(article_view) do -%>
+  <%= element_view_for(article_view) do |el| -%>
     <div class="headline">
       <%= el.render :headline %>
     </div>

--- a/spec/dummy/app/views/alchemy/elements/_secrets_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_secrets_view.html.erb
@@ -1,5 +1,5 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element) do |el| -%>
+<%- cache(secrets_view) do -%>
+  <%= element_view_for(secrets_view) do |el| -%>
     <div class="passwords">
       <%= el.render :passwords %>
     </div>

--- a/spec/dummy/config/alchemy/config.yml
+++ b/spec/dummy/config/alchemy/config.yml
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-#
 # == This is the global Alchemy configuration file
 #
 
@@ -13,23 +11,21 @@ require_ssl: false
 #
 # The amount of time of inactivity in minutes after which the user is kicked out of his current session.
 #
-# INFO: This is only active in production environments
+# NOTE: This is only active in production environments
 #
 auto_logout_time: 30
 
 # === Redirect Options
 #
-#   redirect_index            [Boolean]   # You can disable the redirect to first child page for not public pages.
 #   redirect_to_public_child  [Boolean]   # Alchemy redirects to the first public child page found, if a page is not visible.
 #
-redirect_index: true
 redirect_to_public_child: true
 
 # === Page caching
 #
-# Enable/Disable pagecaching globally.
+# Enable/Disable page caching globally.
 #
-# Hint: You can enable/disable page caching for single Alchemy::PageLayouts in the page_layout.yml file.
+# NOTE: You can enable/disable page caching for single Alchemy::PageLayouts in the page_layout.yml file.
 #
 cache_pages: true
 
@@ -42,7 +38,7 @@ cache_pages: true
 # ==== Config Options:
 #
 #   show_root [Boolean] # Show language root page in sitemap?
-#   show_flag [Boolean] # Enables the Checkbox in Page#update overlay. So your customer can set the visibilit of pages in the sitemap.
+#   show_flag [Boolean] # Enables the Checkbox in Page#update overlay. So your customer can set the visibility of pages in the sitemap.
 #
 sitemap:
   show_root: true
@@ -50,20 +46,25 @@ sitemap:
 
 # === URL nesting
 #
-# Since Alchemy 2.6.0 page urls are nested, respectivley to their tree position.
+# Since Alchemy 2.6.0, page urls are nested, respectively to their tree position.
 #
 # Disable +url_nesting+ to get slug only urls.
 #
-# NOTE: After changing the url_nesting, you should run one of these convert rake task:
+# NOTE: After changing the url_nesting, you should run one of these convert rake tasks:
 #
 #   rake alchemy:convert:urlnames:to_nested
 #   rake alchemy:convert:urlnames:to_slug
 #
 url_nesting: true
 
+# === Default items per page in admin views
+#
+# In Alchemy's Admin, change how many items you would get shown per page by Kaminari
+items_per_page: 15
+
 # === Picture rendering settings
 #
-# Alchemy uses Dragonfly to render images. Use {:image_size => "XXXxYYY", :crop => BOOLEAN [true]} to resize images.
+# Alchemy uses Dragonfly to render images. Use {size: "XXXxYYY", crop: BOOLEAN [true]} to resize images.
 #
 # See http://markevans.github.com/dragonfly for further infos.
 #
@@ -71,15 +72,20 @@ url_nesting: true
 #
 #   output_image_jpg_quality  [Integer]       # If image gets rendered as JPG this is the quality setting for it. (Default 85)
 #   preprocess_image_resize   [String]        # Use this option to resize images to that value. Downsizing example: '1000x1000>' (Default nil)
-#   image_output_format       [String]        # The global image output format setting.
+#   image_output_format       [String]        # The global image output format setting. (Default +original+)
 #
-# TIP: You can always override the output format in the options of your Essence. I.E. {:format => :gif}
+# NOTE: You can always override the output format in the options of your Essence. I.E. {format: 'gif'}
 #
 output_image_jpg_quality: 85
 preprocess_image_resize:
-image_output_format: jpg
+image_output_format: original
 
-# This is the default language for new sites.
+# This is used by the seeder to create the default site.
+default_site:
+  name: Default Site
+  host: "*"
+
+# This is the default language when a new site gets created.
 default_language:
   code: de
   name: Deutsch
@@ -88,11 +94,11 @@ default_language:
 
 # === Mailer Settings:
 #
-# To send Mails via contact forms you can create your form fields here and set which fields are to be validated.
+# To send emails via contact forms, you can create your form fields here and set which fields are to be validated.
 #
 # === Validating fields:
 #
-# Pass the field name as symbol and a message_id (will be translated) to :validate_fields:
+# Pass the field name as a symbol and a message_id (will be translated) to :validate_fields:
 #
 # ==== Options:
 #
@@ -119,7 +125,8 @@ mailer:
   mail_from: your.mail@your-domain.com
   mail_to: your.mail@your-domain.com
   subject: A new contact form message
-  fields: [salutation, firstname, lastname, address, zip, city, phone, email, message]
+  fields:
+    [salutation, firstname, lastname, address, zip, city, phone, email, message]
   validate_fields: [lastname, email]
 
 # === User roles
@@ -151,12 +158,14 @@ uploader:
   upload_limit: 50
   file_size_limit: 100
   allowed_filetypes:
-    pictures:
-    - :jpg
-    - :jpeg
-    - :gif
-    - :png
-    attachments: ['*']
+    alchemy/attachments:
+      - "*"
+    alchemy/pictures:
+      - jpg
+      - jpeg
+      - gif
+      - png
+      - svg
 
 # === Link Target Options
 #
@@ -187,3 +196,6 @@ format_matchers:
   email: !ruby/regexp '/\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/'
   url: !ruby/regexp '/\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?\z/ix'
   link_url: !ruby/regexp '/^(mailto:|\/|[a-z]+:\/\/)/'
+
+# The layout used for rendering the +alchemy/admin/pages#show+ action.
+admin_page_preview_layout: application

--- a/spec/dummy/config/alchemy/config.yml.defaults
+++ b/spec/dummy/config/alchemy/config.yml.defaults
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-#
 # == This is the global Alchemy configuration file
 #
 
@@ -59,9 +57,14 @@ sitemap:
 #
 url_nesting: true
 
+# === Default items per page in admin views
+#
+# In Alchemy's Admin, change how many items you would get shown per page by Kaminari
+items_per_page: 15
+
 # === Picture rendering settings
 #
-# Alchemy uses Dragonfly to render images. Use {:image_size => "XXXxYYY", :crop => BOOLEAN [true]} to resize images.
+# Alchemy uses Dragonfly to render images. Use {size: "XXXxYYY", crop: BOOLEAN [true]} to resize images.
 #
 # See http://markevans.github.com/dragonfly for further infos.
 #
@@ -192,3 +195,6 @@ format_matchers:
   email: !ruby/regexp '/\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/'
   url: !ruby/regexp '/\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?\z/ix'
   link_url: !ruby/regexp '/^(mailto:|\/|[a-z]+:\/\/)/'
+
+# The layout used for rendering the +alchemy/admin/pages#show+ action.
+admin_page_preview_layout: application

--- a/spec/dummy/db/migrate/20160816091133_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/spec/dummy/db/migrate/20160816091133_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -3,6 +3,9 @@
 # work properly
 class ChangeCollationForTagNames < ActiveRecord::Migration[5.1]
   def up
+    # inserted by Alchemy CMS upgrader
+    return unless defined?(ActsAsTaggableOn)
+
     if ActsAsTaggableOn::Utils.using_mysql?
       execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
     end

--- a/spec/dummy/db/migrate/20210925194024_alchemy_four_point_zero.alchemy.rb
+++ b/spec/dummy/db/migrate/20210925194024_alchemy_four_point_zero.alchemy.rb
@@ -1,0 +1,364 @@
+# This migration comes from alchemy (originally 20180226123013)
+# frozen_string_literal: true
+
+class AlchemyFourPointZero < ActiveRecord::Migration[5.0]
+  def up
+    unless table_exists?(:alchemy_attachments)
+      create_table :alchemy_attachments do |t|
+        t.string "name"
+        t.string "file_name"
+        t.string "file_mime_type"
+        t.integer "file_size"
+        t.integer "creator_id"
+        t.integer "updater_id"
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+        t.text "cached_tag_list"
+        t.string "file_uid"
+        t.index ["file_uid"], name: "index_alchemy_attachments_on_file_uid"
+      end
+    end
+
+    unless table_exists?(:alchemy_contents)
+      create_table :alchemy_contents do |t|
+        t.string "name"
+        t.string "essence_type", null: false
+        t.integer "essence_id", null: false
+        t.integer "element_id", null: false
+        t.integer "position"
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+        t.integer "creator_id"
+        t.integer "updater_id"
+        t.index ["element_id", "position"], name: "index_contents_on_element_id_and_position"
+        t.index ["essence_id", "essence_type"], name: "index_alchemy_contents_on_essence_id_and_essence_type", unique: true
+      end
+    end
+
+    unless table_exists?(:alchemy_elements)
+      create_table :alchemy_elements do |t|
+        t.string "name"
+        t.integer "position"
+        t.integer "page_id", null: false
+        t.boolean "public", default: true
+        t.boolean "folded", default: false
+        t.boolean "unique", default: false
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+        t.integer "creator_id"
+        t.integer "updater_id"
+        t.text "cached_tag_list"
+        t.integer "parent_element_id"
+        t.index ["page_id", "parent_element_id"], name: "index_alchemy_elements_on_page_id_and_parent_element_id"
+        t.index ["page_id", "position"], name: "index_elements_on_page_id_and_position"
+      end
+    end
+
+    unless table_exists?(:alchemy_elements_alchemy_pages)
+      create_table :alchemy_elements_alchemy_pages, id: false do |t|
+        t.integer "element_id"
+        t.integer "page_id"
+      end
+    end
+
+    unless table_exists?(:alchemy_essence_booleans)
+      create_table :alchemy_essence_booleans do |t|
+        t.boolean "value"
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+        t.integer "creator_id"
+        t.integer "updater_id"
+        t.index ["value"], name: "index_alchemy_essence_booleans_on_value"
+      end
+    end
+
+    unless table_exists?(:alchemy_essence_dates)
+      create_table :alchemy_essence_dates do |t|
+        t.datetime "date"
+        t.integer "creator_id"
+        t.integer "updater_id"
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+      end
+    end
+
+    unless table_exists?(:alchemy_essence_files)
+      create_table :alchemy_essence_files do |t|
+        t.integer "attachment_id"
+        t.string "title"
+        t.string "css_class"
+        t.integer "creator_id"
+        t.integer "updater_id"
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+        t.string "link_text"
+        t.index ["attachment_id"], name: "index_alchemy_essence_files_on_attachment_id"
+      end
+    end
+
+    unless table_exists?(:alchemy_essence_htmls)
+      create_table :alchemy_essence_htmls do |t|
+        t.text "source"
+        t.integer "creator_id"
+        t.integer "updater_id"
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+      end
+    end
+
+    unless table_exists?(:alchemy_essence_links)
+      create_table :alchemy_essence_links do |t|
+        t.string "link"
+        t.string "link_title"
+        t.string "link_target"
+        t.string "link_class_name"
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+        t.integer "creator_id"
+        t.integer "updater_id"
+      end
+    end
+
+    unless table_exists?(:alchemy_essence_pictures)
+      create_table :alchemy_essence_pictures do |t|
+        t.integer "picture_id"
+        t.string "caption"
+        t.string "title"
+        t.string "alt_tag"
+        t.string "link"
+        t.string "link_class_name"
+        t.string "link_title"
+        t.string "css_class"
+        t.string "link_target"
+        t.integer "creator_id"
+        t.integer "updater_id"
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+        t.string "crop_from"
+        t.string "crop_size"
+        t.string "render_size"
+        t.index ["picture_id"], name: "index_alchemy_essence_pictures_on_picture_id"
+      end
+    end
+
+    unless table_exists?(:alchemy_essence_richtexts)
+      create_table :alchemy_essence_richtexts do |t|
+        t.text "body"
+        t.text "stripped_body"
+        t.boolean "public"
+        t.integer "creator_id"
+        t.integer "updater_id"
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+      end
+    end
+
+    unless table_exists?(:alchemy_essence_selects)
+      create_table :alchemy_essence_selects do |t|
+        t.string "value"
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+        t.integer "creator_id"
+        t.integer "updater_id"
+        t.index ["value"], name: "index_alchemy_essence_selects_on_value"
+      end
+    end
+
+    unless table_exists?(:alchemy_essence_texts)
+      create_table :alchemy_essence_texts do |t|
+        t.text "body"
+        t.string "link"
+        t.string "link_title"
+        t.string "link_class_name"
+        t.boolean "public", default: false
+        t.string "link_target"
+        t.integer "creator_id"
+        t.integer "updater_id"
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+      end
+    end
+
+    unless table_exists?(:alchemy_folded_pages)
+      create_table :alchemy_folded_pages do |t|
+        t.integer "page_id", null: false
+        t.integer "user_id", null: false
+        t.boolean "folded", default: false
+        t.index ["page_id", "user_id"], name: "index_alchemy_folded_pages_on_page_id_and_user_id", unique: true
+      end
+    end
+
+    unless table_exists?(:alchemy_languages)
+      create_table :alchemy_languages do |t|
+        t.string "name"
+        t.string "language_code"
+        t.string "frontpage_name"
+        t.string "page_layout", default: "intro"
+        t.boolean "public", default: false
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+        t.integer "creator_id"
+        t.integer "updater_id"
+        t.boolean "default", default: false
+        t.string "country_code", default: "", null: false
+        t.integer "site_id", null: false
+        t.string "locale"
+        t.index ["language_code", "country_code"], name: "index_alchemy_languages_on_language_code_and_country_code"
+        t.index ["language_code"], name: "index_alchemy_languages_on_language_code"
+        t.index ["site_id"], name: "index_alchemy_languages_on_site_id"
+      end
+    end
+
+    unless table_exists?(:alchemy_legacy_page_urls)
+      create_table :alchemy_legacy_page_urls do |t|
+        t.string "urlname", null: false
+        t.integer "page_id", null: false
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+        t.index ["page_id"], name: "index_alchemy_legacy_page_urls_on_page_id"
+        t.index ["urlname"], name: "index_alchemy_legacy_page_urls_on_urlname"
+      end
+    end
+
+    unless table_exists?(:alchemy_pages)
+      create_table :alchemy_pages do |t|
+        t.string "name"
+        t.string "urlname"
+        t.string "title"
+        t.string "language_code"
+        t.boolean "language_root"
+        t.string "page_layout"
+        t.text "meta_keywords"
+        t.text "meta_description"
+        t.integer "lft"
+        t.integer "rgt"
+        t.integer "parent_id"
+        t.integer "depth"
+        t.boolean "visible", default: false
+        t.integer "locked_by"
+        t.boolean "restricted", default: false
+        t.boolean "robot_index", default: true
+        t.boolean "robot_follow", default: true
+        t.boolean "sitemap", default: true
+        t.boolean "layoutpage", default: false
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+        t.integer "creator_id"
+        t.integer "updater_id"
+        t.integer "language_id"
+        t.text "cached_tag_list"
+        t.datetime "published_at"
+        t.datetime "public_on"
+        t.datetime "public_until"
+        t.datetime "locked_at"
+        t.index ["language_id"], name: "index_pages_on_language_id"
+        t.index ["locked_at", "locked_by"], name: "index_alchemy_pages_on_locked_at_and_locked_by"
+        t.index ["parent_id", "lft"], name: "index_pages_on_parent_id_and_lft"
+        t.index ["public_on", "public_until"], name: "index_alchemy_pages_on_public_on_and_public_until"
+        t.index ["rgt"], name: "index_alchemy_pages_on_rgt"
+        t.index ["urlname"], name: "index_pages_on_urlname"
+      end
+    end
+
+    unless table_exists?(:alchemy_pictures)
+      create_table :alchemy_pictures do |t|
+        t.string "name"
+        t.string "image_file_name"
+        t.integer "image_file_width"
+        t.integer "image_file_height"
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+        t.integer "creator_id"
+        t.integer "updater_id"
+        t.string "upload_hash"
+        t.text "cached_tag_list"
+        t.string "image_file_uid"
+        t.integer "image_file_size"
+        t.string "image_file_format"
+      end
+    end
+
+    unless table_exists?(:alchemy_sites)
+      create_table :alchemy_sites do |t|
+        t.string "host"
+        t.string "name"
+        t.datetime "created_at", null: false, precision: 6
+        t.datetime "updated_at", null: false, precision: 6
+        t.boolean "public", default: false
+        t.text "aliases"
+        t.boolean "redirect_to_primary_host"
+        t.index ["host", "public"], name: "alchemy_sites_public_hosts_idx"
+        t.index ["host"], name: "index_alchemy_sites_on_host"
+      end
+    end
+
+    unless table_exists?(:taggings)
+      create_table :taggings do |t|
+        t.integer "tag_id"
+        t.string "taggable_type"
+        t.integer "taggable_id"
+        t.string "tagger_type"
+        t.integer "tagger_id"
+        t.string "context", limit: 128
+        t.datetime "created_at", precision: 6
+        t.index ["context"], name: "index_taggings_on_context"
+        t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+        t.index ["tag_id"], name: "index_taggings_on_tag_id"
+        t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
+        t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+        t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+        t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+        t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+        t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+      end
+    end
+
+    unless table_exists?(:tags)
+      create_table :tags do |t|
+        t.string "name"
+        t.integer "taggings_count", default: 0
+        t.index ["name"], name: "index_tags_on_name", unique: true
+      end
+    end
+
+    unless foreign_key_exists?(:alchemy_contents, column: :element_id)
+      add_foreign_key :alchemy_contents, :alchemy_elements,
+        column: :element_id,
+        on_update: :cascade,
+        on_delete: :cascade,
+        name: :alchemy_contents_element_id_fkey
+    end
+
+    unless foreign_key_exists?(:alchemy_elements, column: :page_id)
+      add_foreign_key :alchemy_elements, :alchemy_pages,
+        column: :page_id,
+        on_update: :cascade,
+        on_delete: :cascade,
+        name: :alchemy_elements_page_id_fkey
+    end
+  end
+
+  def down
+    drop_table(:alchemy_attachments) if table_exists?(:alchemy_attachments)
+    drop_table(:alchemy_contents) if table_exists?(:alchemy_contents)
+    drop_table(:alchemy_elements) if table_exists?(:alchemy_elements)
+    drop_table(:alchemy_elements_alchemy_pages) if table_exists?(:alchemy_elements_alchemy_pages)
+    drop_table(:alchemy_essence_booleans) if table_exists?(:alchemy_essence_booleans)
+    drop_table(:alchemy_essence_dates) if table_exists?(:alchemy_essence_dates)
+    drop_table(:alchemy_essence_files) if table_exists?(:alchemy_essence_files)
+    drop_table(:alchemy_essence_htmls) if table_exists?(:alchemy_essence_htmls)
+    drop_table(:alchemy_essence_links) if table_exists?(:alchemy_essence_links)
+    drop_table(:alchemy_essence_pictures) if table_exists?(:alchemy_essence_pictures)
+    drop_table(:alchemy_essence_richtexts) if table_exists?(:alchemy_essence_richtexts)
+    drop_table(:alchemy_essence_selects) if table_exists?(:alchemy_essence_selects)
+    drop_table(:alchemy_essence_texts) if table_exists?(:alchemy_essence_texts)
+    drop_table(:alchemy_folded_pages) if table_exists?(:alchemy_folded_pages)
+    drop_table(:alchemy_languages) if table_exists?(:alchemy_languages)
+    drop_table(:alchemy_legacy_page_urls) if table_exists?(:alchemy_legacy_page_urls)
+    drop_table(:alchemy_pages) if table_exists?(:alchemy_pages)
+    drop_table(:alchemy_pictures) if table_exists?(:alchemy_pictures)
+    drop_table(:alchemy_sites) if table_exists?(:alchemy_sites)
+    drop_table(:taggings) if table_exists?(:taggings)
+    drop_table(:tags) if table_exists?(:tags)
+  end
+end

--- a/spec/dummy/db/migrate/20210925194025_migrate_tags_to_gutentag.alchemy.rb
+++ b/spec/dummy/db/migrate/20210925194025_migrate_tags_to_gutentag.alchemy.rb
@@ -1,0 +1,42 @@
+# This migration comes from alchemy (originally 20180227224537)
+# frozen_string_literal: true
+
+class MigrateTagsToGutentag < ActiveRecord::Migration[5.0]
+  def up
+    return if table_exists?(:gutentag_tags)
+
+    remove_index :taggings, :taggable_id
+    remove_column :taggings, :tagger_id, :integer
+    remove_index :taggings, :taggable_type
+    remove_column :taggings, :tagger_type, :string
+    remove_index :taggings, column: [:taggable_id, :taggable_type, :context], name: 'index_taggings_on_taggable_id_and_taggable_type_and_context'
+    remove_column :taggings, :context, :string, limit: 128
+    if index_exists? :taggings, [:tag_id, :taggable_id, :taggable_type], unique: true, name: 'taggings_idx'
+      rename_index :taggings, 'taggings_idx', 'unique_taggings'
+    else
+      add_index :taggings, [:taggable_type, :taggable_id, :tag_id], unique: true, name: 'unique_taggings'
+    end
+    if index_exists? :taggings, [:taggable_id, :taggable_type], name: 'taggings_idy'
+      rename_index :taggings, 'taggings_idy', 'index_gutentag_taggings_on_taggable_id_and_taggable_type'
+    else
+      add_index :taggings, [:taggable_type, :taggable_id]
+    end
+    add_column :taggings, :updated_at, :datetime, precision: 6
+    change_column_null :taggings, :tag_id, false
+    change_column_null :taggings, :taggable_id, false
+    change_column_null :taggings, :taggable_type, false
+    change_column_null :taggings, :created_at, false, Time.current
+    change_column_null :taggings, :updated_at, false, Time.current
+    rename_table :taggings, :gutentag_taggings
+
+    change_column_null :tags, :name, false
+    add_index :tags, :taggings_count
+    rename_table :tags, :gutentag_tags
+
+    %i(alchemy_attachments alchemy_elements alchemy_pages alchemy_pictures).each do |table|
+      if column_exists? table, :cached_tag_list
+        remove_column table, :cached_tag_list
+      end
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20210925194026_add_fixed_to_alchemy_elements.alchemy.rb
+++ b/spec/dummy/db/migrate/20210925194026_add_fixed_to_alchemy_elements.alchemy.rb
@@ -1,0 +1,7 @@
+# This migration comes from alchemy (originally 20180519204655)
+class AddFixedToAlchemyElements < ActiveRecord::Migration[5.0]
+  def change
+    add_column :alchemy_elements, :fixed, :boolean, default: false, null: false
+    add_index :alchemy_elements, :fixed
+  end
+end

--- a/spec/dummy/db/migrate/6_add_taggings_counter_cache_to_tags.alchemy.rb
+++ b/spec/dummy/db/migrate/6_add_taggings_counter_cache_to_tags.alchemy.rb
@@ -3,6 +3,9 @@ class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[5.1]
   def self.up
     add_column :tags, :taggings_count, :integer, default: 0
 
+    # inserted by Alchemy CMS upgrader
+    return unless defined?(ActsAsTaggableOn)
+
     ActsAsTaggableOn::Tag.reset_column_information
     ActsAsTaggableOn::Tag.find_each do |tag|
       ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210923092559) do
+ActiveRecord::Schema.define(version: 20210925194026) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,7 +24,6 @@ ActiveRecord::Schema.define(version: 20210923092559) do
     t.integer "updater_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "cached_tag_list"
     t.string "file_uid"
     t.index ["file_uid"], name: "index_alchemy_attachments_on_file_uid"
   end
@@ -64,9 +63,10 @@ ActiveRecord::Schema.define(version: 20210923092559) do
     t.integer "creator_id"
     t.integer "updater_id"
     t.integer "cell_id"
-    t.text "cached_tag_list"
     t.integer "parent_element_id"
+    t.boolean "fixed", default: false, null: false
     t.index ["cell_id"], name: "index_alchemy_elements_on_cell_id"
+    t.index ["fixed"], name: "index_alchemy_elements_on_fixed"
     t.index ["page_id", "parent_element_id"], name: "index_alchemy_elements_on_page_id_and_parent_element_id"
     t.index ["page_id", "position"], name: "index_elements_on_page_id_and_position"
   end
@@ -236,7 +236,6 @@ ActiveRecord::Schema.define(version: 20210923092559) do
     t.integer "creator_id"
     t.integer "updater_id"
     t.integer "language_id"
-    t.text "cached_tag_list"
     t.datetime "published_at"
     t.datetime "public_on"
     t.datetime "public_until"
@@ -259,7 +258,6 @@ ActiveRecord::Schema.define(version: 20210923092559) do
     t.integer "creator_id"
     t.integer "updater_id"
     t.string "upload_hash"
-    t.text "cached_tag_list"
     t.string "image_file_uid"
     t.integer "image_file_size"
     t.string "image_file_format"
@@ -277,29 +275,22 @@ ActiveRecord::Schema.define(version: 20210923092559) do
     t.index ["host"], name: "index_alchemy_sites_on_host"
   end
 
-  create_table "taggings", id: :serial, force: :cascade do |t|
-    t.integer "tag_id"
-    t.integer "taggable_id"
-    t.string "taggable_type"
-    t.integer "tagger_id"
-    t.string "tagger_type"
-    t.string "context"
-    t.datetime "created_at"
-    t.index ["context"], name: "index_taggings_on_context"
-    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
-    t.index ["tag_id"], name: "index_taggings_on_tag_id"
-    t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
-    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
-    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
-    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
-    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
-    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  create_table "gutentag_taggings", id: :serial, force: :cascade do |t|
+    t.integer "tag_id", null: false
+    t.integer "taggable_id", null: false
+    t.string "taggable_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["tag_id"], name: "index_gutentag_taggings_on_tag_id"
+    t.index ["taggable_type", "taggable_id", "tag_id"], name: "unique_taggings", unique: true
+    t.index ["taggable_type", "taggable_id"], name: "index_gutentag_taggings_on_taggable_type_and_taggable_id"
   end
 
-  create_table "tags", id: :serial, force: :cascade do |t|
-    t.string "name"
+  create_table "gutentag_tags", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
     t.integer "taggings_count", default: 0
-    t.index ["name"], name: "index_tags_on_name", unique: true
+    t.index ["name"], name: "index_gutentag_tags_on_name", unique: true
+    t.index ["taggings_count"], name: "index_gutentag_tags_on_taggings_count"
   end
 
   add_foreign_key "alchemy_cells", "alchemy_pages", column: "page_id", name: "alchemy_cells_page_id_fkey", on_update: :cascade, on_delete: :cascade

--- a/spec/features/fulltext_search_feature_spec.rb
+++ b/spec/features/fulltext_search_feature_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe "Fulltext search" do
   let!(:search_page) do
-    create(:alchemy_page, :public, name: "Suche", page_layout: "search", do_not_autogenerate: false)
+    create(:alchemy_page, :public, name: "Suche", page_layout: "search", autogenerate_elements: true)
   end
 
   it "form has correct path in the form tag" do

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Alchemy::Content do
   let(:element) { build(:alchemy_element, name: "foo") }
 
   let(:content) do
-    described_class.build(element, definition)
+    described_class.new(definition.merge(element: element))
   end
 
   let(:definition) do
@@ -57,7 +57,7 @@ RSpec.describe Alchemy::Content do
     let(:element) { create(:alchemy_element, name: "foo") }
 
     let(:content) do
-      described_class.create_from_scratch(element, definition)
+      described_class.create(definition.merge(element: element))
     end
 
     let(:definition) do

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -11,14 +11,30 @@ RSpec.describe Alchemy::Page do
     create(:alchemy_element, :with_contents, page: page, name: "secrets")
   end
 
+  describe "searchable_contents" do
+    subject { page.searchable_contents }
+
+    let(:searchable_element) do
+      create(:alchemy_element, :with_contents, page: page, name: "mixed")
+    end
+
+    let(:searchable_contents) do
+      searchable_element.contents.where(name: %w[title public image])
+    end
+
+    it "returns searchable contents" do
+      expect(subject).to eq(searchable_contents)
+    end
+  end
+
   describe "searchable_essence_texts" do
     subject { page.searchable_essence_texts }
 
-    let(:searchable_text) do
+    let!(:searchable_text) do
       searchable_element.content_by_name(:headline).essence
     end
 
-    let(:not_searchable_text) do
+    let!(:not_searchable_text) do
       secret_element.content_by_name(:passwords).essence
     end
 
@@ -30,11 +46,11 @@ RSpec.describe Alchemy::Page do
   describe "searchable_essence_richtexts" do
     subject { page.searchable_essence_richtexts }
 
-    let(:searchable_richtext) do
+    let!(:searchable_richtext) do
       searchable_element.content_by_name(:text).essence
     end
 
-    let(:not_searchable_richtext) do
+    let!(:not_searchable_richtext) do
       secret_element.content_by_name(:confidential).essence
     end
 
@@ -46,11 +62,11 @@ RSpec.describe Alchemy::Page do
   describe "searchable_essence_pictures" do
     subject { page.searchable_essence_pictures }
 
-    let(:searchable_picture) do
+    let!(:searchable_picture) do
       searchable_element.content_by_name(:image).essence
     end
 
-    let(:not_searchable_picture) do
+    let!(:not_searchable_picture) do
       secret_element.content_by_name(:image).essence
     end
 


### PR DESCRIPTION
Alchemy 4.3 changed the way how contents get created and removed the `descendent_contents` relation from page.

Made it more robust by adding our own `searchable_contents` relation.

That's why we also needed to raise the minimum supported Alchemy version to 4.3 and above.