### PR TITLE
Do not allow Alchemy 4.3 and above

### DIFF
--- a/alchemy-pg_search.gemspec
+++ b/alchemy-pg_search.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "alchemy_cms", [">= 4.0", "< 5.0"]
+  spec.add_runtime_dependency "alchemy_cms", [">= 4.0", "< 4.3"]
   spec.add_runtime_dependency "pg_search", ["~> 2.1"]
   spec.add_runtime_dependency "pg"
 


### PR DESCRIPTION
Alchemy 4.3 made some breaking changes to how contents are
created and removed the descendents_contents relation from
page.