### PR TITLE
Fix initializing without element in attribute

### DIFF
--- a/lib/alchemy/pg_search/content_extension.rb
+++ b/lib/alchemy/pg_search/content_extension.rb
@@ -1,10 +1,8 @@
 module Alchemy::PgSearch::ContentExtension
   module ClassMethods
     def new(attributes)
-      element = attributes[:element]
-      definition = element.content_definition_for(attributes[:name])
       super.tap do |content|
-        content.searchable = definition.key?(:searchable) ? definition[:searchable] : true
+        content.searchable = content.definition.key?(:searchable) ? content.definition[:searchable] : true
       end
     end
 

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -47,3 +47,15 @@
 
 - name: searchresults
   unique: true
+
+- name: content_test
+  contents:
+    - name: without_searchable
+      type: EssenceText
+      default: "This is my public title."
+    - name: with_searchable_enabled
+      type: EssenceText
+      searchable: true
+    - name: with_searchable_disabled
+      type: EssenceText
+      searchable: false

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -1,75 +1,30 @@
 require "spec_helper"
 
 RSpec.describe Alchemy::Content do
-  let(:element) { build(:alchemy_element, name: "foo") }
+  let(:element) { create(:alchemy_element, :with_contents, name: "content_test") }
+  let(:content) { element.content_by_name(content_name) }
+  let(:content_name) { :without_searchable }
 
-  let(:content) do
-    described_class.new(definition.merge(element: element))
-  end
+  context "Without searchable" do
+    let(:content_name) { :without_searchable }
 
-  let(:definition) do
-    {
-      name: "bar",
-      type: essence_type,
-      searchable: searchable,
-    }.with_indifferent_access
-  end
-
-  let(:searchable) { true }
-  let(:essence_type) { "EssenceText" }
-
-  before do
-    expect(element).to receive(:content_definition_for).at_least(:once) do
-      definition
-    end
-  end
-
-  context "with searchable set to true" do
-    let(:searchable) { true }
-
-    it "sets the searchable attribute to true" do
+    it "should be searchable" do
       expect(content.searchable).to be(true)
     end
   end
 
-  context "with searchable set to false" do
-    let(:searchable) { false }
+  context "With searchable enabled" do
+    let(:content_name) { :with_searchable_enabled }
 
-    it "sets the searchable attribute to false" do
-      expect(content.searchable).to be(false)
-    end
-  end
-
-  context "with searchable key missing" do
-    let(:definition) do
-      {
-        name: "bar",
-        type: essence_type,
-      }.with_indifferent_access
-    end
-
-    it "sets the searchable attribute to true" do
+    it "should be searchable" do
       expect(content.searchable).to be(true)
     end
   end
 
-  describe ".after_update" do
-    let(:element) { create(:alchemy_element, name: "foo") }
+  context "With searchable disabled" do
+    let(:content_name) { :with_searchable_disabled }
 
-    let(:content) do
-      described_class.create(definition.merge(element: element))
-    end
-
-    let(:definition) do
-      {
-        name: "bar",
-        type: "EssenceText",
-        searchable: true,
-      }.with_indifferent_access
-    end
-
-    it "updates the value for `searchable`" do
-      content.update!(searchable: false)
+    it "should be not searchable" do
       expect(content.searchable).to be(false)
     end
   end


### PR DESCRIPTION
In Alchemy the Content can be initialize with an element or an element_id. If the Content was initialized with an element_id the content_extension led to an exception.