### PR TITLE
Allow to exclude pages, elements and ingredients from search index

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,30 @@ Every `EssenceText`, `EssenceRichtext` and `EssencePicture` will be indexed unle
 
 ### Disable Indexing
 
-Simply pass `searchable: false` to your content definitions and Alchemy will not index results from that particular content.
+#### Exclude whole pages from the search index
+
+Pass `searchable: false` to your page layout definitions and Alchemy will not index that particular page.
+
+```yaml
+# page_layouts.yml
+- name: secret_page
+  searchable: false
+  elements:
+    - secret_sauce
+```
+
+#### Exclude contents from being indexed
+
+Pass `searchable: false` to your content definitions and Alchemy will not index that particular content.
 
 ```yaml
 # elements.yml
 - name: secrets
   contents:
-  - name: passwords
-    type: EssenceText
-    searchable: false
-    default: 'This is my secret password.'
+    - name: passwords
+      type: EssenceText
+      searchable: false
+      default: 'This is my secret password.'
 ```
   
 ### Configure Behavior

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ Pass `searchable: false` to your content definitions and Alchemy will not index 
       searchable: false
       default: 'This is my secret password.'
 ```
+
+The same works for `ingredients` as well
+
+```yaml
+# elements.yml
+- name: secrets
+  ingredients:
+    - name: passwords
+      type: Text
+      searchable: false
+      default: 'This is my secret password.'
+```
   
 ### Configure Behavior
          

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ The same works for `ingredients` as well
       searchable: false
       default: 'This is my secret password.'
 ```
-  
+
 ### Configure Behavior
-         
+
 Configure the gem in an initializer. The default configurations are:
 
 ```ruby
@@ -78,7 +78,7 @@ Alchemy::PgSearch.config = {
 }
 ```
 
-You can also overwrite the default multisearch configuration to use other search strategies. For more information take 
+You can also overwrite the default multisearch configuration to use other search strategies. For more information take
 a look into the [PgSearch Readme](https://github.com/Casecommons/pg_search#configuring-multi-search).
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -42,7 +42,21 @@ Pass `searchable: false` to your page layout definitions and Alchemy will not in
     - secret_sauce
 ```
 
-#### Exclude contents from being indexed
+#### Exclude whole elements from the search index
+
+Pass `searchable: false` to your element definitions and Alchemy will not index that particular element.
+
+```yaml
+# elements.yml
+- name: secret_sauce
+  searchable: false
+  ingredients:
+    - name: sauce
+      type: Text
+      default: 'This is my secret sauce.'
+```
+
+#### Exclude single contents from being indexed
 
 Pass `searchable: false` to your content definitions and Alchemy will not index that particular content.
 

--- a/app/extensions/alchemy/pg_search/element_extension.rb
+++ b/app/extensions/alchemy/pg_search/element_extension.rb
@@ -1,6 +1,7 @@
 module Alchemy::PgSearch::ElementExtension
   def searchable?
-    public? && page.searchable? && page_version.public?
+    (definition.key?(:searchable) ? definition[:searchable] : true) &&
+      public? && page.searchable? && page_version.public?
   end
 end
 

--- a/app/extensions/alchemy/pg_search/ingredient_extension.rb
+++ b/app/extensions/alchemy/pg_search/ingredient_extension.rb
@@ -3,17 +3,18 @@ module Alchemy::PgSearch::IngredientExtension
     base.include PgSearch::Model
     base.multisearchable(
       against: [
-        :value
+        :value,
       ],
-      additional_attributes: -> (ingredient) { { page_id: ingredient.element.page.id } },
-      if: :searchable?
+      additional_attributes: ->(ingredient) { { page_id: ingredient.element.page.id } },
+      if: :searchable?,
     )
   end
 
   def searchable?
-    value.present? && Alchemy::PgSearch.is_searchable?(type) && !!element&.searchable?
+    Alchemy::PgSearch.is_searchable?(type) &&
+      (definition.key?(:searchable) ? definition[:searchable] : true) &&
+      value.present? && !!element&.searchable?
   end
 end
 
 Alchemy::Ingredient.prepend(Alchemy::PgSearch::IngredientExtension)
-

--- a/app/extensions/alchemy/pg_search/page_extension.rb
+++ b/app/extensions/alchemy/pg_search/page_extension.rb
@@ -10,13 +10,14 @@ module Alchemy::PgSearch::PageExtension
         :meta_keywords,
         :name,
       ],
-      additional_attributes: -> (page) { { page_id: page.id } },
-      if: :searchable?
+      additional_attributes: ->(page) { { page_id: page.id } },
+      if: :searchable?,
     )
   end
 
   def searchable?
-    public? && !layoutpage?
+    (definition.key?(:searchable) ? definition[:searchable] : true) &&
+      public? && !layoutpage?
   end
 
   private

--- a/spec/models/element_spec.rb
+++ b/spec/models/element_spec.rb
@@ -1,43 +1,57 @@
 require "spec_helper"
 
 RSpec.describe Alchemy::Element do
-  let(:searchable_element) do
+  let(:element) do
     page_version = create(:alchemy_page_version, :published)
     create(:alchemy_element, page_version: page_version)
   end
 
   describe "searchable?" do
-    describe "public element and public page" do
-      it 'should be searchable' do
-        expect(searchable_element.searchable?).to be(true)
+    subject { element.searchable? }
+
+    context "public element and public page" do
+      it "should be searchable" do
+        is_expected.to be(true)
+      end
+
+      context "but configured as not searchable" do
+        before do
+          expect(element).to receive(:definition).at_least(:once) do
+            {
+              searchable: false,
+            }
+          end
+        end
+
+        it { is_expected.to be(false) }
       end
     end
 
-    describe "public element and not published page" do
+    context "public element and not published page" do
       let(:element) do
         create(:alchemy_element)
       end
 
-      it 'should not be searchable' do
-        expect(element.searchable?).to be(false)
+      it "should not be searchable" do
+        is_expected.to be(false)
       end
     end
 
-    describe "public element and not published page_version" do
-      let(:searchable_element) do
+    context "public element and not published page_version" do
+      let(:element) do
         page_version = create(:alchemy_page_version)
         create(:alchemy_element, page_version: page_version)
       end
 
-      it 'should not be searchable' do
-        expect(searchable_element.searchable?).to be(false)
+      it "should not be searchable" do
+        is_expected.to be(false)
       end
     end
 
-    describe "not public element" do
-      it 'should not be searchable' do
-        searchable_element.public = false
-        expect(searchable_element.searchable?).to be(false)
+    context "not public element" do
+      it "should not be searchable" do
+        element.public = false
+        is_expected.to be(false)
       end
     end
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -4,28 +4,34 @@ RSpec.describe Alchemy::Page do
   let(:page) { create(:alchemy_page, :public) }
 
   describe "searchable?" do
-    describe "public and not restricted page" do
-      let(:page) { create(:alchemy_page, :public) }
+    subject { page.searchable? }
 
-      it 'should be searchable' do
-        expect(page.searchable?).to be(true)
+    context "public and not restricted page" do
+      it { is_expected.to be(true) }
+
+      context "but configured as not searchable" do
+        before do
+          expect(page).to receive(:definition).at_least(:once) do
+            {
+              searchable: false,
+            }
+          end
+        end
+
+        it { is_expected.to be(false) }
       end
     end
 
-    describe "not public page" do
+    context "not public page" do
       let(:page) { create(:alchemy_page) }
 
-      it 'should not be searchable' do
-        expect(page.searchable?).to be(false)
-      end
+      it { is_expected.to be(false) }
     end
 
-    describe "layout page" do
+    context "layout page" do
       let(:page) { create(:alchemy_page, :public, :layoutpage) }
 
-      it 'should not be searchable' do
-        expect(page.searchable?).to be(false)
-      end
+      it { is_expected.to be(false) }
     end
   end
 
@@ -37,6 +43,21 @@ RSpec.describe Alchemy::Page do
     it "should not remove the document, if the page is searchable" do
       page.save
       expect(PgSearch::Document.count).to eq(1)
+    end
+
+    context "but configured as not searchable" do
+      before do
+        expect(page).to receive(:definition).at_least(:once) do
+          {
+            searchable: false,
+          }
+        end
+      end
+
+      it "should remove the document" do
+        page.save
+        expect(PgSearch::Document.count).to eq(0)
+      end
     end
 
     describe "unpublished page" do


### PR DESCRIPTION
## Exclude pages from the search index

A page can be configured as not searchable in the page layout config.

```yaml
# page_layouts.yml
- name: secret_page
  searchable: false
```

## Exclude whole elements from the search index

Pass `searchable: false` to your element definitions and Alchemy will not index that particular element.

```yaml
# elements.yml
- name: secret_sauce
  searchable: false
  ingredients:
    - name: sauce
      type: Text
      default: 'This is my secret sauce.'
```

## The same now works for `ingredients` as well

```yaml
# elements.yml
- name: secrets
  ingredients:
    - name: passwords
      type: Text
      searchable: false
      default: 'This is my secret password.'
```