### PR TITLE
Fix creating elements that has searchable defined

### DIFF
--- a/app/extensions/alchemy/pg_search/element_extension.rb
+++ b/app/extensions/alchemy/pg_search/element_extension.rb
@@ -1,7 +1,14 @@
 module Alchemy::PgSearch::ElementExtension
+  def self.prepended(base)
+    base.attr_writer :searchable
+  end
+
+  def searchable
+    definition.key?(:searchable) ? definition[:searchable] : true
+  end
+
   def searchable?
-    (definition.key?(:searchable) ? definition[:searchable] : true) &&
-      public? && page.searchable? && page_version.public?
+    searchable && public? && page.searchable? && page_version.public?
   end
 end
 

--- a/spec/models/element_spec.rb
+++ b/spec/models/element_spec.rb
@@ -6,6 +6,23 @@ RSpec.describe Alchemy::Element do
     create(:alchemy_element, page_version: page_version)
   end
 
+  describe "#searchable" do
+    subject { element.searchable }
+
+    before do
+      expect(Alchemy::Element).to receive(:definition_by_name).at_least(:once) do
+        {
+          name: "foo",
+          searchable: false,
+        }
+      end
+    end
+
+    let(:element) { Alchemy::Element.create!(name: "foo", page_version: create(:alchemy_page_version)) }
+
+    it { is_expected.to be false }
+  end
+
   describe "searchable?" do
     subject { element.searchable? }
 


### PR DESCRIPTION
This attribute is not in the db schema. We need to add an attribute writer in order to be able to create an element.