### PR TITLE
Page searchable toggle

### DIFF
--- a/app/extensions/alchemy/pg_search/page_extension.rb
+++ b/app/extensions/alchemy/pg_search/page_extension.rb
@@ -17,7 +17,7 @@ module Alchemy::PgSearch::PageExtension
 
   def searchable?
     (definition.key?(:searchable) ? definition[:searchable] : true) &&
-      public? && !layoutpage?
+      searchable && public? && !layoutpage?
   end
 
   private

--- a/lib/alchemy/pg_search/engine.rb
+++ b/lib/alchemy/pg_search/engine.rb
@@ -17,6 +17,9 @@ module Alchemy
         # reindex the page after it was published
         Alchemy.publish_targets << Alchemy::PgSearch::IndexPageJob
 
+        # enable searchable flag in page form
+        Alchemy.enable_searchable = true
+
         # configure multiselect to find also partial words
         # @link https://github.com/Casecommons/pg_search#searching-using-different-search-features
         ::PgSearch.multisearch_options = {

--- a/spec/dummy/db/migrate/20230119143813_restrict_on_delete_page_id_foreign_key_from_alchemy_nodes.alchemy.rb
+++ b/spec/dummy/db/migrate/20230119143813_restrict_on_delete_page_id_foreign_key_from_alchemy_nodes.alchemy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+# This migration comes from alchemy (originally 20220514072456)
+
+class RestrictOnDeletePageIdForeignKeyFromAlchemyNodes < ActiveRecord::Migration[6.0]
+  def up
+    remove_foreign_key :alchemy_nodes, :alchemy_pages
+    add_foreign_key :alchemy_nodes, :alchemy_pages, column: :page_id, on_delete: :restrict
+  end
+
+  def down
+    remove_foreign_key :alchemy_nodes, :alchemy_pages
+    add_foreign_key :alchemy_nodes, :alchemy_pages, column: :page_id, on_delete: :cascade
+  end
+end

--- a/spec/dummy/db/migrate/20230119143814_add_playsinline_to_alchemy_essence_videos.alchemy.rb
+++ b/spec/dummy/db/migrate/20230119143814_add_playsinline_to_alchemy_essence_videos.alchemy.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# This migration comes from alchemy (originally 20220622130905)
+
+class AddPlaysinlineToAlchemyEssenceVideos < ActiveRecord::Migration[6.0]
+  def change
+    return if column_exists?(:alchemy_essence_videos, :playsinline)
+
+    add_column :alchemy_essence_videos, :playsinline, :boolean, default: false, null: false
+  end
+end

--- a/spec/dummy/db/migrate/20230119143815_add_searchable_to_alchemy_pages.alchemy.rb
+++ b/spec/dummy/db/migrate/20230119143815_add_searchable_to_alchemy_pages.alchemy.rb
@@ -1,0 +1,8 @@
+# This migration comes from alchemy (originally 20230119112425)
+class AddSearchableToAlchemyPages < ActiveRecord::Migration[6.0]
+  def change
+    return if column_exists?(:alchemy_pages, :searchable)
+
+    add_column :alchemy_pages, :searchable, :boolean, default: true, null: false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_26_125413) do
+ActiveRecord::Schema.define(version: 2023_01_19_143815) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -179,6 +179,7 @@ ActiveRecord::Schema.define(version: 2022_08_26_125413) do
     t.boolean "loop", default: false, null: false
     t.boolean "muted", default: false, null: false
     t.string "preload"
+    t.boolean "playsinline", default: false, null: false
     t.index ["attachment_id"], name: "index_alchemy_essence_videos_on_attachment_id"
   end
 
@@ -300,6 +301,7 @@ ActiveRecord::Schema.define(version: 2022_08_26_125413) do
     t.datetime "legacy_public_on"
     t.datetime "legacy_public_until"
     t.datetime "locked_at"
+    t.boolean "searchable", default: true, null: false
     t.index ["creator_id"], name: "index_alchemy_pages_on_creator_id"
     t.index ["language_id"], name: "index_alchemy_pages_on_language_id"
     t.index ["locked_at", "locked_by"], name: "index_alchemy_pages_on_locked_at_and_locked_by"
@@ -390,7 +392,7 @@ ActiveRecord::Schema.define(version: 2022_08_26_125413) do
   add_foreign_key "alchemy_essence_pages", "alchemy_pages", column: "page_id"
   add_foreign_key "alchemy_ingredients", "alchemy_elements", column: "element_id", on_delete: :cascade
   add_foreign_key "alchemy_nodes", "alchemy_languages", column: "language_id"
-  add_foreign_key "alchemy_nodes", "alchemy_pages", column: "page_id", on_delete: :cascade
+  add_foreign_key "alchemy_nodes", "alchemy_pages", column: "page_id", on_delete: :restrict
   add_foreign_key "alchemy_page_versions", "alchemy_pages", column: "page_id", on_delete: :cascade
   add_foreign_key "alchemy_pages", "alchemy_languages", column: "language_id"
   add_foreign_key "alchemy_picture_thumbs", "alchemy_pictures", column: "picture_id"

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -140,6 +140,28 @@ describe Alchemy::PgSearch::Search do
         end
       end
     end
+
+    context 'page searchable' do
+      let(:searchable) { true }
+      let!(:page) { create(:alchemy_page, :public, name: "Searchable Page", searchable: searchable) }
+      let(:result) { Alchemy::PgSearch::Search.search "searchable" }
+
+      before do
+        Alchemy::PgSearch::Search.rebuild
+      end
+
+      it 'should find one page' do
+        expect(result.length).to eq(1)
+      end
+
+      context 'searchable disabled' do
+        let(:searchable) { false }
+
+        it 'should not find any page' do
+          expect(result.length).to eq(0)
+        end
+      end
+    end
   end
 
   context 'search' do


### PR DESCRIPTION
It is possible to remove pages from the index that have a disabled searchable - flag. This is the companion commit to the PR in Alchemy CMS.

Reference: https://github.com/AlchemyCMS/alchemy_cms/pull/2414