### PR TITLE
Update to Alchemy 6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rails", "~> 6.0.0"
-ENV.fetch("ALCHEMY_BRANCH", "6.0-stable").tap do |branch|
+ENV.fetch("ALCHEMY_BRANCH", "6.1-stable").tap do |branch|
   gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: branch
 end
 gem "sassc-rails"

--- a/alchemy-pg_search.gemspec
+++ b/alchemy-pg_search.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "alchemy_cms", [">= 6.0", "< 7"]
+  spec.add_runtime_dependency "alchemy_cms", [">= 6.1", "< 7"]
   spec.add_runtime_dependency "pg_search", ["~> 2.1"]
   spec.add_runtime_dependency "pg"
 

--- a/app/controller/alchemy/pg_search/controller_methods.rb
+++ b/app/controller/alchemy/pg_search/controller_methods.rb
@@ -70,11 +70,14 @@ module Alchemy
       end
 
       def search_result_page_layout
-        page_layout = PageLayout.get_all_by_attributes(searchresults: true).first
-        if page_layout.nil?
+        # search for page layout with the attribute `searchresults: true`
+        page_layouts = PageLayout.all.select do |page_layout|
+          page_layout.key?(:searchresults) && page_layout[:searchresults].to_s.casecmp(true.to_s).zero?
+        end
+        if page_layouts.nil?
           raise "No searchresults page layout found. Please add page layout with `searchresults: true` into your `page_layouts.yml` file."
         end
-        page_layout
+        page_layouts.first
       end
 
       def paginate_per


### PR DESCRIPTION
PageLayout.get_all_by_attributes was removed in Alchemy 6.1 and is necessary to update the method to find the search result page layout.