### PR TITLE
Make migrations more error tolerant

### DIFF
--- a/db/migrate/20141211105526_add_searchable_to_alchemy_essence_texts.rb
+++ b/db/migrate/20141211105526_add_searchable_to_alchemy_essence_texts.rb
@@ -1,5 +1,5 @@
-class AddSearchableToAlchemyEssenceTexts < ActiveRecord::Migration[5.1]
+class AddSearchableToAlchemyEssenceTexts < ActiveRecord::Migration[6.1]
   def change
-    add_column :alchemy_essence_texts, :searchable, :boolean, default: true
+    add_column :alchemy_essence_texts, :searchable, :boolean, default: true, if_not_exists: true
   end
 end

--- a/db/migrate/20141211105942_add_searchable_to_alchemy_essence_richtexts.rb
+++ b/db/migrate/20141211105942_add_searchable_to_alchemy_essence_richtexts.rb
@@ -1,5 +1,5 @@
-class AddSearchableToAlchemyEssenceRichtexts < ActiveRecord::Migration[5.1]
+class AddSearchableToAlchemyEssenceRichtexts < ActiveRecord::Migration[6.1]
   def change
-    add_column :alchemy_essence_richtexts, :searchable, :boolean, default: true
+    add_column :alchemy_essence_richtexts, :searchable, :boolean, default: true, if_not_exists: true
   end
 end

--- a/db/migrate/20141211110126_add_searchable_to_alchemy_essence_pictures.rb
+++ b/db/migrate/20141211110126_add_searchable_to_alchemy_essence_pictures.rb
@@ -1,5 +1,5 @@
-class AddSearchableToAlchemyEssencePictures < ActiveRecord::Migration[5.1]
+class AddSearchableToAlchemyEssencePictures < ActiveRecord::Migration[6.1]
   def change
-    add_column :alchemy_essence_pictures, :searchable, :boolean, default: true
+    add_column :alchemy_essence_pictures, :searchable, :boolean, default: true, if_not_exists: true
   end
 end

--- a/db/migrate/20210923081905_move_searchable_to_contents.rb
+++ b/db/migrate/20210923081905_move_searchable_to_contents.rb
@@ -1,5 +1,9 @@
-class MoveSearchableToContents < ActiveRecord::Migration[5.0]
+class MoveSearchableToContents < ActiveRecord::Migration[6.1]
   def change
+    if column_exists? :alchemy_contents, :searchable
+      return
+    end
+
     add_column :alchemy_contents, :searchable, :boolean, default: true
 
     {

--- a/db/migrate/20220826125413_add_page_id_column_to_pg_search_documents.rb
+++ b/db/migrate/20220826125413_add_page_id_column_to_pg_search_documents.rb
@@ -1,5 +1,7 @@
 class AddPageIdColumnToPgSearchDocuments < ActiveRecord::Migration[6.0]
   def change
-    add_reference :pg_search_documents, :page, index: true
+    unless column_exists? :pg_search_documents, :page
+      add_reference :pg_search_documents, :page, index: true
+    end
   end
 end


### PR DESCRIPTION
Update the migrations to Rails 6.1 and use the if_not_exists - option to make the migrations more robust. Some fields are now available in AlchemyCMS, which would break the migration on new installations.