### PR TITLE
Fix PgSearch config initializer

### DIFF
--- a/lib/alchemy/pg_search/engine.rb
+++ b/lib/alchemy/pg_search/engine.rb
@@ -19,7 +19,9 @@ module Alchemy
 
         # enable searchable flag in page form
         Alchemy.enable_searchable = true
+      end
 
+      initializer "alchemy.pg_search.config", after: :finisher_hook do
         # configure multiselect to find also partial words
         # @link https://github.com/Casecommons/pg_search#searching-using-different-search-features
         ::PgSearch.multisearch_options = {


### PR DESCRIPTION
The to_prepare - block was running before the default after_initialize - blocks. So the config for the dictionary couldn't be set from outside. It was always 'simple'. With the finisher_hook - initializer, all initializer from the hosting Rails application ran, before the config is set.