### PR TITLE
Update configuration section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,17 @@ The same works for `ingredients` as well
 Configure the gem in an initializer. The default configurations are:
 
 ```ruby
-Alchemy::PgSearch.config = {
-  dictionary: 'simple',
-  paginate_per: 10
-}
+Rails.application.config.before_initialize do
+  Alchemy::PgSearch.config = {
+    dictionary: 'simple',
+    paginate_per: 10
+  }
+end
 ```
+
+> [!NOTE]  
+> Be aware that `before_initialize` is used. Otherwise the configuration will not have an effect, because of the load
+> order in Rails.
 
  Configuration Name | Default Value | Description                                                                                                                                                                                                                                                                                                 
 --------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Add a note to the point, that configuration has to be set in the `before_initialize` - block. The previous solution (https://github.com/AlchemyCMS/alchemy-pg_search/pull/43) was using the finisher_hook, which was intersecting with Sprockets.