### PR TITLE
Allow different search strings in preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ place additional elements (maybe a header image or additional text blocks) on th
 # elements.yml
 - name: searchresults
   unique: true
+  ingredients:
+    - role: search_string
+      hint: The is only for presentational purposes in the Alchemy preview
+      default: lorem
+      type: Text
 ```
 
 and then use the view helpers to render the search form on the page layout partial and the search results on the element

--- a/app/controller/alchemy/pg_search/controller_methods.rb
+++ b/app/controller/alchemy/pg_search/controller_methods.rb
@@ -34,9 +34,7 @@ module Alchemy
       # @see Alchemy::PagesHelper#render_search_form
       #
       def perform_search
-        if self.class == Alchemy::Admin::PagesController && params[:query].blank?
-          params[:query] = "lorem"
-        end
+        set_preview_query
         return if params[:query].blank?
         @search_results = search_results
         if paginate_per
@@ -82,6 +80,16 @@ module Alchemy
 
       def paginate_per
         Alchemy::PgSearch.config[:paginate_per]
+      end
+
+      private
+
+      def set_preview_query
+        if self.class == Alchemy::Admin::PagesController && params[:query].blank?
+          element = search_result_page.draft_version.elements.named(:searchresults).first
+          
+          params[:query] = element&.value_for("search_string") || "lorem"
+        end
       end
     end
   end


### PR DESCRIPTION
Allow different search strings in Alchemy Preview of the search. This the way the preview can actually show a result if the site does not have the default 'lorem' search string.