### PR TITLE
Fix preview if search_result_page is nil

### DIFF
--- a/app/controller/alchemy/pg_search/controller_methods.rb
+++ b/app/controller/alchemy/pg_search/controller_methods.rb
@@ -86,7 +86,7 @@ module Alchemy
 
       def set_preview_query
         if self.class == Alchemy::Admin::PagesController && params[:query].blank?
-          element = search_result_page.draft_version.elements.named(:searchresults).first
+          element = search_result_page&.draft_version&.elements&.named(:searchresults)&.first
           
           params[:query] = element&.value_for("search_string") || "lorem"
         end


### PR DESCRIPTION
If you create the search page for the first time there is the possibility that the search_result_page is nil. Add safe operators to prevent an exception in that case.