### PR TITLE
Mark page id as optional on pg_search_document

### DIFF
--- a/app/extensions/alchemy/pg_search/pg_search_document_extension.rb
+++ b/app/extensions/alchemy/pg_search/pg_search_document_extension.rb
@@ -1,6 +1,6 @@
 module Alchemy::PgSearch::PgSearchDocumentExtension
   def self.prepended(base)
-    base.belongs_to :page, class_name: "::Alchemy::Page", foreign_key: "page_id"
+    base.belongs_to :page, class_name: "::Alchemy::Page", foreign_key: "page_id", optional: true
   end
 
   ##


### PR DESCRIPTION
Mark the relation of the page as optional to make the pg_search_document model also for other purposes usable. Without the optional option an update will fail and pg_search will silently not store the documents.