### PR TITLE
Use stripped_body field for Richtext ingredient

### DIFF
--- a/app/extensions/alchemy/pg_search/ingredient_extension.rb
+++ b/app/extensions/alchemy/pg_search/ingredient_extension.rb
@@ -25,5 +25,6 @@ end
 # add the PgSearch model to all ingredients
 Alchemy::Ingredient.prepend(Alchemy::PgSearch::IngredientExtension)
 
-# only enable the search for Text, Richtext, and Picture
+# add custom content fields for Richtext, and Picture
 Alchemy::Ingredients::Picture.multisearchable(Alchemy::PgSearch::IngredientExtension.multisearch_config.merge({against: [:caption]}))
+Alchemy::Ingredients::Richtext.multisearchable(Alchemy::PgSearch::IngredientExtension.multisearch_config.merge({against: [:stripped_body]}))

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -101,7 +101,7 @@ describe Alchemy::Ingredient do
   end
 
   describe Alchemy::Ingredients::Richtext do
-    let(:ingredient) { create(:alchemy_ingredient_richtext, value: content, element: element) }
+    let(:ingredient) { create(:alchemy_ingredient_richtext, value: "<b>foo</b> bar", element: element) }
 
     it_behaves_like "it is searchable"
     it_behaves_like "it is in search index"


### PR DESCRIPTION
Use the stripped_body field for Richtext ingredients to prevent HTML tags in the search index. The HTML fields are bloating the content field in the pg_search_documents table.