### PR TITLE
Introduce a search_class configuration into Alchemy

### DIFF
--- a/app/controller/alchemy/pg_search/controller_methods.rb
+++ b/app/controller/alchemy/pg_search/controller_methods.rb
@@ -47,7 +47,7 @@ module Alchemy
       # @return [Array]
       #
       def search_results
-        Alchemy::PgSearch.search params[:query], ability: current_ability
+        Alchemy.search_class.search params[:query], ability: current_ability
       end
 
       # A view helper that loads the search result page.

--- a/lib/alchemy-pg_search.rb
+++ b/lib/alchemy-pg_search.rb
@@ -2,6 +2,9 @@ require "alchemy/pg_search/engine"
 require "alchemy/pg_search/config"
 
 module Alchemy
+  mattr_accessor :search_class
+  @@search_class = PgSearch
+
   module PgSearch
     SEARCHABLE_INGREDIENTS = %w[Text Richtext Picture]
 


### PR DESCRIPTION
The default config is Alchemy::PgSearch, but it is possible to change the class from outside.