### PR TITLE
Disable transaction in rebuild step

### DIFF
--- a/lib/alchemy-pg_search.rb
+++ b/lib/alchemy-pg_search.rb
@@ -19,7 +19,7 @@ module Alchemy
     # index all supported Alchemy models
     def self.rebuild
       [Alchemy::Page, Alchemy::Ingredient].each do |model|
-        ::PgSearch::Multisearch.rebuild(model)
+        ::PgSearch::Multisearch.rebuild(model, transactional: false)
       end
     end
 


### PR DESCRIPTION
The default rebuild behavior is to have a transaction, which is creating a huge amount of insert before commiting those. These function is only for the initial setup and it is not important to have it transactional.