### PR TITLE
Add searchable_created_at field

### DIFF
--- a/app/extensions/alchemy/pg_search/page_extension.rb
+++ b/app/extensions/alchemy/pg_search/page_extension.rb
@@ -10,7 +10,7 @@ module Alchemy::PgSearch::PageExtension
         :meta_keywords,
         :name,
       ],
-      additional_attributes: ->(page) { { page_id: page.id } },
+      additional_attributes: ->(page) { { page_id: page.id, searchable_created_at: page.published_at } },
       if: :searchable?,
     )
   end

--- a/app/services/alchemy/search/search_page.rb
+++ b/app/services/alchemy/search/search_page.rb
@@ -6,6 +6,12 @@ module Alchemy
       def self.perform_search(params, ability: nil)
         search_results = Alchemy.search_class.search(params[:query], ability:)
         search_results = search_results&.page(params[:page])&.per(paginate_per) if paginate_per.present?
+
+        # order the documents by searchable_created_at and use the ranking order as second order argument
+        if params[:sort] == "date"
+          search_results.order_values.unshift("pg_search_documents.searchable_created_at DESC")
+        end
+
         search_results
       end
 

--- a/db/migrate/20241105092236_add_document_created_at_to_pg_search_documents.rb
+++ b/db/migrate/20241105092236_add_document_created_at_to_pg_search_documents.rb
@@ -1,0 +1,6 @@
+class AddDocumentCreatedAtToPgSearchDocuments < ActiveRecord::Migration[7.1]
+  def change
+    add_column :pg_search_documents, :searchable_created_at, :datetime, if_not_exists: true
+    add_index :pg_search_documents, :searchable_created_at, if_not_exists: true
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_08_083843) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_06_130317) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -256,7 +256,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_08_083843) do
     t.datetime "updated_at", null: false
     t.bigint "page_id"
     t.virtual "searchable_content", type: :tsvector, as: "to_tsvector('simple'::regconfig, COALESCE(content, ''::text))", stored: true
+    t.datetime "searchable_created_at"
     t.index ["page_id"], name: "index_pg_search_documents_on_page_id"
+    t.index ["searchable_created_at"], name: "index_pg_search_documents_on_searchable_created_at"
     t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable"
   end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -69,4 +69,14 @@ RSpec.describe Alchemy::Page do
       end
     end
   end
+
+  describe "additional_attributes" do
+    it "stores page_id" do
+      expect(page.pg_search_document.page_id).to eq(page.id)
+    end
+
+    it "stores searchable created_at" do
+      expect(page.pg_search_document.searchable_created_at).to eq(page.published_at)
+    end
+  end
 end

--- a/spec/services/alchemy/search/search_page_spec.rb
+++ b/spec/services/alchemy/search/search_page_spec.rb
@@ -40,6 +40,29 @@ RSpec.describe Alchemy::Search::SearchPage do
         end
       end
     end
+
+    context "sort" do
+      let(:query) { "page" }
+      let(:params) { {query:, sort:} }
+      let!(:first_page) { create(:alchemy_page, :public, published_at: "1999-08-01 00:00") }
+      let!(:second_page) { create(:alchemy_page, :public, title: "Page 2") }
+
+      context "by relevance" do
+        let(:sort) { "relevance" }
+
+        it "sorts by pg_search ranking" do
+          expect(subject.first.searchable).to eq(first_page)
+        end
+      end
+
+      context "by date" do
+        let(:sort) { "date" }
+
+        it "sorts by searchable_created_at" do
+          expect(subject.first.searchable).to eq(second_page)
+        end
+      end
+    end
   end
 
   context '#paginate_per' do


### PR DESCRIPTION
Add a new searchable_created_at field to store the created_at timestamps in the search index to allow sorting and/or filterting over these data. Also add a sort parameter to sort by searchable_created_at or the rank (which is the default).