### PR TITLE
Use public_on instead of published_at for pg_search_documents

### DIFF
--- a/app/extensions/alchemy/pg_search/page_extension.rb
+++ b/app/extensions/alchemy/pg_search/page_extension.rb
@@ -10,7 +10,7 @@ module Alchemy::PgSearch::PageExtension
         :meta_keywords,
         :name,
       ],
-      additional_attributes: ->(page) { { page_id: page.id, searchable_created_at: page.published_at } },
+      additional_attributes: ->(page) { { page_id: page.id, searchable_created_at: page.public_on } },
       if: :searchable?,
     )
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Alchemy::Page do
     end
 
     it "stores searchable created_at" do
-      expect(page.pg_search_document.searchable_created_at).to eq(page.published_at)
+      expect(page.pg_search_document.searchable_created_at).to eq(page.public_on)
     end
   end
 end


### PR DESCRIPTION
The public_on date will only be set the first time a page was published. Published_at instead will be set each time a page is published. It makes more sense to prefer public_on.