### PR TITLE
Use an inner select for CanCanCan abilities

### DIFF
--- a/spec/lib/alchemy-pg_search_spec.rb
+++ b/spec/lib/alchemy-pg_search_spec.rb
@@ -101,6 +101,16 @@ describe Alchemy::PgSearch do
         it 'should find two pages' do
           expect(result.length).to eq(2)
         end
+
+        context "with other search documents" do
+          let!(:other_search_document) do
+            PgSearch::Document.new(content: "Page").save(validate: false)
+          end
+
+          it 'should find three pages' do
+            expect(result.length).to eq(3)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
The previous solution only worked if the pg_search_document has a page_id. If another search document without a page relation was added and a ability was present, the document couldn't be found, because the generate SQL had an inner join to that page_id. The new solution is using a sub select and only filters pg_search_documents, that have a page_id relation.