### PR TITLE
wip: Use PgSearch::Document.rebuild for page reindex

### DIFF
--- a/app/extensions/alchemy/pg_search/page_extension.rb
+++ b/app/extensions/alchemy/pg_search/page_extension.rb
@@ -6,24 +6,18 @@ module Alchemy::PgSearch::PageExtension
     base.after_save :remove_unpublished_page
     base.multisearchable(
       against: [
-        :meta_description,
-        :meta_keywords,
         :name,
+        :searchable_content
       ],
       additional_attributes: ->(page) { { page_id: page.id, searchable_created_at: page.public_on } },
       if: :searchable?,
     )
   end
 
-  def searchable?
-    (definition.key?(:searchable) ? definition[:searchable] : true) &&
-      searchable && public? && !layoutpage?
-  end
-
   private
 
   def remove_unpublished_page
-    Alchemy::PgSearch.remove_page(self) unless searchable?
+    ::PgSearch::Document.delete_by(page_id: id) unless searchable?
   end
 end
 

--- a/app/extensions/alchemy/search/element_extension.rb
+++ b/app/extensions/alchemy/search/element_extension.rb
@@ -10,6 +10,10 @@ module Alchemy::Search::ElementExtension
   def searchable?
     searchable && public? && page.searchable? && page_version.public?
   end
+
+  def searchable_content
+    ingredients.select(&:searchable?).map(&:searchable_content).join(" ")
+  end
 end
 
 Alchemy::Element.prepend(Alchemy::Search::ElementExtension)

--- a/app/extensions/alchemy/search/page_extension.rb
+++ b/app/extensions/alchemy/search/page_extension.rb
@@ -5,6 +5,10 @@ module Alchemy::Search::PageExtension
     (definition.key?(:searchable) ? definition[:searchable] : true) &&
       searchable && public? && !layoutpage?
   end
+
+  def searchable_content
+    all_elements.includes(ingredients: {element: :page}).map(&:searchable_content).join(" ")
+  end
 end
 
 Alchemy::Page.prepend(Alchemy::Search::PageExtension)


### PR DESCRIPTION
Adds a searchable_content method to page extension as well and configure multisearch that it uses this to build its content for pg search. That way we can remove our custom rebuild implementation.