### PR TITLE
Use PgSearch::Document.rebuild for page reindex

### DIFF
--- a/app/extensions/alchemy/pg_search/page_extension.rb
+++ b/app/extensions/alchemy/pg_search/page_extension.rb
@@ -6,24 +6,18 @@ module Alchemy::PgSearch::PageExtension
     base.after_save :remove_unpublished_page
     base.multisearchable(
       against: [
-        :meta_description,
-        :meta_keywords,
         :name,
+        :searchable_content
       ],
       additional_attributes: ->(page) { { page_id: page.id, searchable_created_at: page.public_on } },
       if: :searchable?,
     )
   end
 
-  def searchable?
-    (definition.key?(:searchable) ? definition[:searchable] : true) &&
-      searchable && public? && !layoutpage?
-  end
-
   private
 
   def remove_unpublished_page
-    Alchemy::PgSearch.remove_page(self) unless searchable?
+    ::PgSearch::Document.delete_by(page_id: id) unless searchable?
   end
 end
 

--- a/app/extensions/alchemy/search/element_extension.rb
+++ b/app/extensions/alchemy/search/element_extension.rb
@@ -10,6 +10,10 @@ module Alchemy::Search::ElementExtension
   def searchable?
     searchable && public? && page.searchable? && page_version.public?
   end
+
+  def searchable_content
+    ingredients.select(&:searchable?).map(&:searchable_content).join(" ").squish
+  end
 end
 
 Alchemy::Element.prepend(Alchemy::Search::ElementExtension)

--- a/app/extensions/alchemy/search/page_extension.rb
+++ b/app/extensions/alchemy/search/page_extension.rb
@@ -5,6 +5,10 @@ module Alchemy::Search::PageExtension
     (definition.key?(:searchable) ? definition[:searchable] : true) &&
       searchable && public? && !layoutpage?
   end
+
+  def searchable_content
+    all_elements.includes(ingredients: {element: :page}).map(&:searchable_content).join(" ")
+  end
 end
 
 Alchemy::Page.prepend(Alchemy::Search::PageExtension)

--- a/app/jobs/alchemy/pg_search/index_page_job.rb
+++ b/app/jobs/alchemy/pg_search/index_page_job.rb
@@ -2,7 +2,7 @@ module Alchemy
   module PgSearch
     class IndexPageJob < BaseJob
       def perform(page)
-        PgSearch.index_page(page)
+        page.update_pg_search_document
       end
     end
   end

--- a/spec/jobs/index_page_job_spec.rb
+++ b/spec/jobs/index_page_job_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Alchemy::PgSearch::IndexPageJob, type: :job do
 
   let(:page) { create(:alchemy_page, :public) }
 
-  it "calls the index_page - method" do
-    expect(Alchemy::PgSearch).to receive(:index_page).with(page)
+  it "calls the update_pg_search_document - method" do
+    expect(page).to receive(:update_pg_search_document)
     described_class.perform_now(page)
   end
 end

--- a/spec/models/element_spec.rb
+++ b/spec/models/element_spec.rb
@@ -72,4 +72,29 @@ RSpec.describe Alchemy::Element do
       end
     end
   end
+
+  describe "searchable_content" do
+    let(:element) do
+      page_version = create(:alchemy_page_version, :published)
+      create(:alchemy_element, :with_ingredients, name: "ingredient_test", public: true, page_version: page_version)
+    end
+    let!(:first_ingredient) { create(:alchemy_ingredient_headline, value: "foo bar", element: element) }
+
+    subject { element.searchable_content }
+
+    it "should contain ingredient content" do
+      is_expected.to eq("foo bar")
+    end
+
+    context "ignore not searchable elements" do
+      before do
+        element.public = false
+        element.save
+      end
+
+      it "should not find the unsearchable content" do
+        is_expected.to_not include("foo")
+      end
+    end
+  end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -40,9 +40,10 @@ RSpec.describe Alchemy::Page do
       PgSearch::Document.create(page_id: page.id, content: "foo")
     end
 
+    subject { page.save }
+
     it "should not remove the document, if the page is searchable" do
-      page.save
-      expect(PgSearch::Document.count).to eq(1)
+      expect { subject }.to change { PgSearch::Document.count }.by(0)
     end
 
     context "but configured as not searchable" do
@@ -55,17 +56,32 @@ RSpec.describe Alchemy::Page do
       end
 
       it "should remove the document" do
-        page.save
+        expect { subject }.to change { PgSearch::Document.count }.by(-1)
+      end
+    end
+
+    context "unpublished page" do
+      let(:page) { create(:alchemy_page) }
+
+      it "should not store the page, if it is not searchable" do
         expect(PgSearch::Document.count).to eq(0)
       end
     end
 
-    describe "unpublished page" do
-      let(:page) { create(:alchemy_page) }
+    context "stored content" do
+      let!(:page) { create(:alchemy_page, :public, name: "Searchable Page", page_layout: "mixed", autogenerate_elements: true) }
+      let(:content) { page.pg_search_document.content }
 
-      it "should remove the document, if the page is not searchable" do
-        page.save
-        expect(PgSearch::Document.count).to eq(0)
+      before do
+        subject
+      end
+
+      it "should store the page name" do
+        expect(content).to start_with("Searchable Page")
+      end
+
+      it "should store the searchable_content" do
+        expect(content).to include("public title")
       end
     end
   end
@@ -77,6 +93,28 @@ RSpec.describe Alchemy::Page do
 
     it "stores searchable created_at" do
       expect(page.pg_search_document.searchable_created_at).to eq(page.public_on)
+    end
+  end
+
+  describe "searchable_content" do
+    let!(:searchable_page) { create(:alchemy_page, :public, name: "Searchable Page", page_layout: "mixed", autogenerate_elements: true) }
+
+    before do
+      PgSearch::Document.destroy_all # clean the whole index
+    end
+
+    subject { searchable_page.searchable_content }
+
+    it "has ingredients" do
+      expect(subject).to include("public title")
+    end
+
+    it "hasn't not searchable ingredient" do
+      expect(subject).to_not include("secret password")
+    end
+
+    it "stores stripped content from ingredient" do
+      expect(subject).to include("public richtext")
     end
   end
 end


### PR DESCRIPTION
Adds a searchable_content method to page extension as well and configure multisearch that it uses this to build its content for pg search. That way we can remove our custom rebuild implementation.