### PR TITLE
Update Alchemy to v7.4.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v2.3.4
+      - name: Install ImageMagick
+        run: sudo apt-get install -y imagemagick
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,14 @@
 name: CI
 
-on: [push, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   RSpec:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,14 @@ on:
 jobs:
   RSpec:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.2", "3.4"]
+        alchemy_cms: ["7.4"]
     env:
       RAILS_ENV: test
+      ALCHEMY_CMS_VERSION: ${{ matrix.alchemy_cms }}
     services:
       postgres:
         image: postgres:12
@@ -31,7 +37,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Prepare database
         run: bundle exec rake alchemy:spec:prepare

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rails", "~> 7.1.0"
-gem "alchemy_cms", "~> 7.0.0"
+gem "alchemy_cms", "~> #{ENV.fetch("ALCHEMY_CMS_VERSION", "7.4")}.0"
 
 gem "sassc-rails"
 gem "sassc", "~> 2.4.0"

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "pg", "~> 1.0"
 gem "puma"
 
 group :test do
-  gem "factory_bot_rails", "~> 4.8.0"
+  gem "factory_bot_rails", "~> 6.5.1"
   gem "capybara"
   gem "pry-byebug"
   gem "launchy"

--- a/alchemy-pg_search.gemspec
+++ b/alchemy-pg_search.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "alchemy_cms", [">= 7.0", "< 8"]
+  spec.add_runtime_dependency "alchemy_cms", [">= 7.4", "< 8"]
   spec.add_runtime_dependency "pg_search", ["~> 2.1"]
   spec.add_runtime_dependency "pg"
 

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -42,6 +42,7 @@ module Dummy
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     config.i18n.available_locales = [:de, :en]
     config.i18n.default_locale = :de
+    config.i18n.fallbacks = [:en]
     I18n.enforce_available_locales = false
     # Don't generate system test files.
     config.generators.system_tests = nil

--- a/spec/features/fulltext_search_feature_spec.rb
+++ b/spec/features/fulltext_search_feature_spec.rb
@@ -103,10 +103,11 @@ RSpec.describe "Fulltext search" do
     end
 
     context "in multi_language mode" do
-      let(:english_language) { create(:alchemy_language, :english) }
-      let(:english_language_root) { create(:alchemy_page, :language_root, language: english_language, name: "Home") }
-      let(:english_page) { create(:alchemy_page, :public, parent_id: english_language_root.id, language: english_language) }
-      let!(:english_element) { create(:alchemy_element, :with_ingredients, page: english_page, name: "article") }
+      let!(:german_language) { create(:alchemy_language, :german) }
+      let(:klingon_language) { create(:alchemy_language, :klingon) }
+      let(:klingon_language_root) { create(:alchemy_page, :language_root, language: klingon_language, name: "Home") }
+      let(:klingon_page) { create(:alchemy_page, :public, parent_id: klingon_language_root.id, language: klingon_language) }
+      let!(:klingon_element) { create(:alchemy_element, :with_ingredients, page: klingon_page, name: "article") }
 
       before do
         element
@@ -114,7 +115,7 @@ RSpec.describe "Fulltext search" do
       end
 
       it "does not display search results from other languages" do
-        english_element.ingredient_by_role("headline").update!(value: "Joes Hardware")
+        klingon_element.ingredient_by_role("headline").update!(value: "Joes Hardware")
         visit("/de/suche?query=Hardware")
         expect(page).to have_css("h2.no_search_results")
         expect(page).to_not have_css(".search_result_list")


### PR DESCRIPTION
- fixed the RSpec tests
- improved CI configurations to test the gem against different Ruby versions
- Increase the Alchemy version to the latest 7.x version as a preparation to upgrade to Alchemy 8.0 