### PR TITLE
Upgrade Alchemy v8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.2", "3.4"]
-        alchemy_cms: ["7.4"]
+        alchemy_cms: ["8.0"]
     env:
       RAILS_ENV: test
       ALCHEMY_CMS_VERSION: ${{ matrix.alchemy_cms }}

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rails", "~> 7.1.0"
-gem "alchemy_cms", "~> #{ENV.fetch("ALCHEMY_CMS_VERSION", "7.4")}.0"
+gem "alchemy_cms", "~> #{ENV.fetch("ALCHEMY_CMS_VERSION", "8.0")}.0"
 
 gem "sassc-rails"
 gem "sassc", "~> 2.4.0"

--- a/alchemy-pg_search.gemspec
+++ b/alchemy-pg_search.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "alchemy_cms", [">= 7.4", "< 8"]
+  spec.add_runtime_dependency "alchemy_cms", [">= 8.0.7", "< 9"]
   spec.add_runtime_dependency "pg_search", ["~> 2.1"]
   spec.add_runtime_dependency "pg"
 

--- a/app/extensions/alchemy/search/element_extension.rb
+++ b/app/extensions/alchemy/search/element_extension.rb
@@ -4,7 +4,7 @@ module Alchemy::Search::ElementExtension
   end
 
   def searchable
-    definition.key?(:searchable) ? definition[:searchable] : true
+    definition.searchable
   end
 
   def searchable?

--- a/app/extensions/alchemy/search/ingredient_extension.rb
+++ b/app/extensions/alchemy/search/ingredient_extension.rb
@@ -5,7 +5,7 @@ module Alchemy::Search::IngredientExtension
 
   def searchable?
     Alchemy.searchable_ingredients.has_key?(type.to_sym) &&
-      (definition.key?(:searchable) ? definition[:searchable] : true) &&
+      definition.searchable &&
       !!element&.searchable?
   end
 end

--- a/app/extensions/alchemy/search/page_extension.rb
+++ b/app/extensions/alchemy/search/page_extension.rb
@@ -2,8 +2,7 @@
 #
 module Alchemy::Search::PageExtension
   def searchable?
-    (definition.key?(:searchable) ? definition[:searchable] : true) &&
-      searchable && public? && !layoutpage?
+    definition.searchable && searchable && public? && !layoutpage?
   end
 
   def searchable_content

--- a/app/services/alchemy/search/search_page.rb
+++ b/app/services/alchemy/search/search_page.rb
@@ -21,17 +21,17 @@ module Alchemy
 
       def self.search_result_page
         @search_result_page ||= begin
-          page_layouts = PageLayout.all.select do |page_layout|
-            page_layout.key?(:searchresults) && page_layout[:searchresults].to_s.casecmp(true.to_s).zero?
+          page_definitions = ::Alchemy::PageDefinition.all.select do |page_definition|
+            page_definition.searchresults
           end
 
-          if page_layouts.nil?
+          if page_definitions.nil?
             raise "No searchresults page layout found. Please add page layout with `searchresults: true` into your `page_layouts.yml` file."
           end
 
           page = Page.published.find_by(
-            page_layout: page_layouts.first["name"],
-            language_id: Language.current.id,
+            page_layout: page_definitions.first.name,
+            language_id: ::Alchemy::Current.language.id,
           )
           if page.nil?
             logger.warn "\n++++++\nNo published search result page found. Please create one or publish your search result page.\n++++++\n"

--- a/lib/alchemy/pg_search/engine.rb
+++ b/lib/alchemy/pg_search/engine.rb
@@ -14,7 +14,7 @@ module Alchemy
         # In development environment, this runs on every code reload, so avoid multiple reindexing jobs
         unless Alchemy.publish_targets.map(&:name).include? 'Alchemy::PgSearch::IndexPageJob'
           # reindex the page after it was published
-          Alchemy.publish_targets << Alchemy::PgSearch::IndexPageJob
+          Alchemy.config.publish_targets << "Alchemy::PgSearch::IndexPageJob"
         end
         # enable searchable flag in page form
         Alchemy.enable_searchable = true

--- a/spec/dummy/config/initializers/alchemy.rb
+++ b/spec/dummy/config/initializers/alchemy.rb
@@ -1,0 +1,271 @@
+Alchemy.configure do |config|
+  # == This is the global Alchemy configuration file
+  #
+
+  # === Auto Log Out Time
+  #
+  # The amount of time of inactivity in minutes after which the user is kicked out of his current session.
+  #
+  # NOTE: This is only active in production environments
+  #
+  # config.auto_logout_time = 30
+
+  # === Page caching
+  #
+  # Enable/Disable page caching globally.
+  #
+  # NOTE: You can enable/disable page caching for single Alchemy::Definitions in the page_layout.yml file.
+  #
+  # config.cache_pages = true
+
+  # === Sitemap
+  #
+  # Alchemy creates a XML, Google compatible, sitemap for you.
+  #
+  # The url is: http://your-domain.tld/sitemap.xml
+  #
+  # ==== Config Options:
+  #
+  #   show_root [Boolean] # Show language root page in sitemap?
+  #   show_flag [Boolean] # Enables the Checkbox in Page#update overlay. So your customer can set the visibility of pages in the sitemap.
+  #
+  # config.sitemap.tap do |sitemap|
+  #   sitemap.show_root = true
+  #   sitemap.show_flag = false
+  # end
+
+  # === Default items per page in admin views
+  #
+  # In Alchemy's Admin, change how many items you would get shown per page by Kaminari
+  # config.items_per_page = 15
+
+  # === Preview window URL configuration
+  #
+  # By default Alchemy uses its internal page preview renderer,
+  # but you can configure it to be any URL instead.
+  #
+  # Basic Auth is supported.
+  #
+  # config.preview = {
+  #   host: https://www.my-static-site.com
+  #   auth:
+  #     username: <%= ENV["BASIC_AUTH_USERNAME"] %>
+  #     password: <%= ENV["BASIC_AUTH_PASSWORD"] %>
+  # }
+  # Preview config per site is supported as well.
+  #
+  # config.preview = {
+  #   My site name:
+  #     host: https://www.my-static-site.com
+  #     auth:
+  #       username: <%= ENV["BASIC_AUTH_USERNAME"] %>
+  #       password: <%= ENV["BASIC_AUTH_PASSWORD"] %>
+  # }
+
+  # === Picture rendering settings
+  #
+  # Alchemy uses Dragonfly to render images. Settings for image rendering are specific to elements and are defined in elements.yml
+  #
+  # Example:
+  # - name: some_element
+  #   ingredients:
+  #   - role: some_picture
+  #     type: Picture
+  #     settings:
+  #       hint: true
+  #       crop: true  # turns on image cropping
+  #       size: '500x500' # image will be cropped to this size
+  #
+  # See http://markevans.github.com/dragonfly for further info.
+  #
+  # ==== Global Options:
+  #
+  #   output_image_quality      [Integer]       # If image gets rendered as JPG or WebP this is the quality setting for it. (Default 85)
+  #   preprocess_image_resize   [String]        # Use this option to resize images to the given size when they are uploaded to the image library. Downsizing example: '1000x1000>' (Default nil)
+  #   image_output_format       [String]        # The global image output format setting. (Default +original+)
+  #
+  # NOTE: You can always override the output format in the settings of your ingredients in elements.yml, I.E. {format: 'gif'}
+  #
+  # config.output_image_quality = 85
+  # config.preprocess_image_resize = nil
+  # config.image_output_format = "original"
+
+  # This is used by the seeder to create the default site.
+  # config.default_site.tap do |default_site|
+  #   default_site.name = "Default Site"
+  #   default_site.host = "*"
+  # end
+
+  # This is the default language when seeding.
+  config.default_language.tap do |default_language|
+    default_language.code = "en"
+    default_language.name = "English"
+    # default_language.page_layout = "index"
+    # default_language.frontpage_name = "Index"
+  end
+
+  # === Mailer Settings:
+  #
+  # To send emails via contact forms, you can create your form fields here and set which fields are to be validated.
+  #
+  # === Validating fields:
+  #
+  # Pass the field name as a symbol and a message_id (will be translated) to :validate_fields:
+  #
+  # ==== Options:
+  #
+  #   page_layout_name:           [String] # A +Alchemy::PageDefinition+ name. Used to render the contactform on a page with this layout.
+  #   fields:                     [Array]  # An Array of fieldnames.
+  #   validate_fields:            [Array]  # An Array of fieldnames to be validated on presence.
+  #
+  # ==== Translating validation messages:
+  #
+  # The validation messages are passed through ::I18n.t so you can translate it in your language yml file.
+  #
+  # ==== Example:
+  #
+  #   de:
+  #     activemodel:
+  #       attributes:
+  #         alchemy/message:
+  #           firstname: Vorname
+  #
+  # config.mailer.tap do |mailer|
+  #   mailer.page_layout_name = "contact"
+  #   mailer.forward_to_page = false
+  #   mailer.mail_success_page = "thanks"
+  #   mailer.mail_from = "your.mail@your-domain.com"
+  #   mailer.mail_to = "your.mail@your-domain.com"
+  #   mailer.subject = "A new contact form message"
+  #   mailer.fields = ["salutation", "firstname", "lastname", "address", "zip", "city", "phone", "email", "message"]
+  #   mailer.validate_fields = ["lastname", "email"]
+  # end
+
+  # === User roles
+  #
+  # You can add own user roles.
+  #
+  # Further documentation for the auth system used please visit:
+  #
+  # https://github.com/ryanb/cancan/wiki
+  #
+  # ==== Translating User roles
+  #
+  # Userroles can be translated inside your the language yml file under:
+  #
+  #   alchemy:
+  #     user_roles:
+  #       rolename: Name of the role
+  #
+  # config.user_roles = ["member", "author", "editor", "admin"]
+
+  # === Uploader Settings
+  #
+  #   upload_limit       [Integer]    # Set an amount of files upload limit of files which can be uploaded at once. Set 0 for unlimited.
+  #   file_size_limit*   [Integer]    # Set a file size limit in mega bytes for a per file limit.
+  #
+  # *) Allow filetypes to upload. Pass * to allow all kind of files.
+  #
+  # config.uploader.tap do |uploader|
+  #   uploader.upload_limit = 50
+  #   uploader.file_size_limit = 100
+  #   uploader.allowed_filetypes.tap do |file_types|
+  #     file_types.alchemy_attachments = ["*"]
+  #     file_types.alchemy_pictures = ["jpg", "jpeg", "gif", "png", "svg", "webp"]
+  #   end
+  # end
+
+  # === Link Target Options
+  #
+  # Values for the link target selectbox inside the page link overlay.
+  # The value gets attached as a data-link-target attribute to the link.
+  #
+  # == Example:
+  #
+  # Open all links set to overlay inside an jQuery UI Dialog Window.
+  #
+  #   jQuery(a[data-link-target="overlay"]).dialog();
+  #
+  # config.link_target_options = ["blank"]
+
+  # === Format matchers
+  #
+  # Named aliases for regular expressions that can be used in various places.
+  # The most common use case is the format validation of ingredients, or attribute validations of your individual models.
+  #
+  # == Example:
+  #
+  #   validates_format_of :url, with: Alchemy.config.format_matchers.url
+  #
+  # config.format_matchers.tap do |format|
+  #   format.email = /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/
+  #   format.url = /\A[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?\z/ix
+  #   format.link_url = /^(tel:|mailto:|\/|[a-z]+:\/\/)/
+  # end
+
+  # The layout used for rendering the +alchemy/admin/pages#show+ action.
+  # config.admin_page_preview_layout = "application"
+
+  # The sizes for the preview size select in the page editor.
+  # config.page_preview_sizes = ["360", "640", "768", "1024", "1280", "1440"]
+
+  # Enable full text search configuration
+  #
+  # It enables a searchable checkbox in the page form to toggle
+  # the searchable field. These information can used in a search
+  # plugin (e.g. https://github.com/AlchemyCMS/alchemy-pg_search).
+  #
+  # == Example
+  #
+  #     # config/initializers/alchemy.rb
+  #     Alchemy.config.page_searchable_checkbox = true
+  #
+  # config.show_page_searchable_checkbox = false
+
+  # The storage adapter for Pictures and Attachments
+  #
+  config.storage_adapter = "dragonfly"
+
+  # Additional JS modules to be imported in the Alchemy admin UI
+  #
+  # Be sure to also pin the modules with +Alchemy.importmap+.
+  #
+  # == Example
+  #
+  #    Alchemy.importmap.pin "flatpickr/de",
+  #      to: "https://ga.jspm.io/npm:flatpickr@4.6.13/dist/l10n/de.js"
+  #
+  # config.admin_js_imports << "flatpickr/de"
+
+  # Additional importmaps to be included in the Alchemy admin UI
+  #
+  # Be sure to also pin modules with +Alchemy.importmap+.
+  #
+  # config.admin_importmaps.add(
+  #   importmap_path: root.join("config/importmap.rb"),
+  #   source_paths: [
+  #     root.join("app/javascript")
+  #   ],
+  #   name: "admin_extension"
+  # )
+
+  # Additional stylesheets to be included in the Alchemy admin UI
+  # config.admin_stylesheets.add("my_app/admin_extension")
+
+  # Define page publish targets
+  #
+  # A publish target is a ActiveJob that gets performed
+  # whenever a user clicks the publish page button.
+  #
+  # Use this to trigger deployment hooks of external
+  # services in an asychronous way.
+  #
+  # config.publish_targets << "MyPublishJob"
+
+  # Configure tabs in the link dialog
+  #
+  # With this configuration that tabs in the link dialog can be extended
+  # without overwriting or defacing the Admin Interface.
+  #
+  # config.link_dialog_tabs << "Acme::LinkTab"
+end

--- a/spec/dummy/config/initializers/dragonfly.rb
+++ b/spec/dummy/config/initializers/dragonfly.rb
@@ -14,7 +14,6 @@
 Dragonfly.app(:alchemy_pictures).configure do
   dragonfly_url nil
   plugin :imagemagick
-  plugin :svg
   secret "2d8312902ae81648d11dd9366413ec54ae03a4c9f09253a2f5d12191b9776966"
   url_format "/pictures/:job/:basename.:ext"
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_02_04_104766) do
+ActiveRecord::Schema[7.1].define(version: 2026_02_04_105344) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,6 +24,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_04_104766) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "file_uid"
+    t.index ["created_at"], name: "index_alchemy_attachments_on_created_at"
     t.index ["creator_id"], name: "index_alchemy_attachments_on_creator_id"
     t.index ["file_uid"], name: "index_alchemy_attachments_on_file_uid"
     t.index ["updater_id"], name: "index_alchemy_attachments_on_updater_id"
@@ -221,6 +222,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_04_104766) do
     t.string "image_file_uid"
     t.integer "image_file_size"
     t.string "image_file_format"
+    t.index ["created_at"], name: "index_alchemy_pictures_on_created_at"
     t.index ["creator_id"], name: "index_alchemy_pictures_on_creator_id"
     t.index ["image_file_name"], name: "index_alchemy_pictures_on_image_file_name"
     t.index ["name"], name: "index_alchemy_pictures_on_name"

--- a/spec/lib/alchemy-pg_search_spec.rb
+++ b/spec/lib/alchemy-pg_search_spec.rb
@@ -8,10 +8,11 @@ describe Alchemy::PgSearch do
     subject { described_class.rebuild }
 
     it 'should have created pages indexed documents' do
-      expect(PgSearch::Document.count).to be(2)
+      expect(PgSearch::Document.count).to be(3)
     end
 
     it "has an additional page (Root Page + 2 created pages)" do
+      PgSearch::Document.first.destroy # remove root page document
       expect { subject }.to change { PgSearch::Document.count }.by(1)
     end
 

--- a/spec/models/element_spec.rb
+++ b/spec/models/element_spec.rb
@@ -11,10 +11,7 @@ RSpec.describe Alchemy::Element do
 
     before do
       expect(Alchemy::Element).to receive(:definition_by_name).at_least(:once) do
-        {
-          name: "foo",
-          searchable: false,
-        }
+        Alchemy::ElementDefinition.new(name: "foo", searchable: false)
       end
     end
 
@@ -34,9 +31,7 @@ RSpec.describe Alchemy::Element do
       context "but configured as not searchable" do
         before do
           expect(element).to receive(:definition).at_least(:once) do
-            {
-              searchable: false,
-            }
+            Alchemy::ElementDefinition.new(searchable: false)
           end
         end
 

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -10,9 +10,7 @@ RSpec.shared_examples_for "it is searchable" do |attribute|
       context "but configured as not searchable" do
         before do
           expect(ingredient).to receive(:definition).at_least(:once) do
-            {
-              searchable: false,
-            }
+            Alchemy::IngredientDefinition.new(searchable: false)
           end
         end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe Alchemy::Page do
       context "but configured as not searchable" do
         before do
           expect(page).to receive(:definition).at_least(:once) do
-            {
-              searchable: false,
-            }
+            Alchemy::PageDefinition.new(searchable: false)
           end
         end
 
@@ -49,9 +47,7 @@ RSpec.describe Alchemy::Page do
     context "but configured as not searchable" do
       before do
         expect(page).to receive(:definition).at_least(:once) do
-          {
-            searchable: false,
-          }
+          Alchemy::PageDefinition.new(searchable: false)
         end
       end
 
@@ -64,7 +60,7 @@ RSpec.describe Alchemy::Page do
       let(:page) { create(:alchemy_page) }
 
       it "should not store the page, if it is not searchable" do
-        expect(PgSearch::Document.count).to eq(0)
+        expect(PgSearch::Document.count).to eq(1)
       end
     end
 


### PR DESCRIPTION
Provide compatibility with the latest versions of Alchemy. v8.0.7 is necessary to run properly, because searchable attribute is required for the ElementDefinition, and IngredientDefinition.

This update has to be a major release, because the Alchemy v8.0.7 is required.

Ref: https://github.com/AlchemyCMS/alchemy_cms/pull/3633