### PR TITLE
Add bin/setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,16 @@ and reindex your database in your Rails console
 $ Alchemy::PgSearch.rebuild
 ```
 
+## Local Development
+
+Run the setup script to install dependencies and prepare the dummy app:
+
+```shell
+$ bin/setup
+```
+
+This installs gems, runs the Alchemy and PgSearch installers, and clears temporary files.
+
 ## Contributing
 
 1. Fork it

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+require "fileutils"
+
+# path to dummy application root.
+APP_ROOT = File.expand_path("../spec/dummy", __dir__)
+
+# path to alchemy gem
+GEM_ROOT = File.expand_path("../", __dir__)
+
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+FileUtils.chdir GEM_ROOT do
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
+end
+
+FileUtils.chdir APP_ROOT do
+  puts "\n== Remove migration files for dummy app =="
+  Dir.glob("db/migrate/*.rb")
+    .reject { |f| f.include?("create_users") || f.include?("pg_search_documents") }
+    .each { |f| FileUtils.rm(f) }
+
+  puts "\n== Create database for dummy app =="
+  system!("bin/rails db:drop")
+  system!("bin/rails db:create")
+
+  puts "\n== Installing Alchemy CMS into dummy app =="
+  system!("bin/rails g alchemy:install --skip --skip-demo-files --auto-accept")
+
+  puts "\n== Installing Alchemy PGSearch into dummy app =="
+  system!("bin/rails g alchemy:pg_search:install")
+
+  puts "\n== Removing old logs and tempfiles =="
+  system! "bin/rails log:clear tmp:clear"
+
+  puts "\n== Removing old logs and tempfiles =="
+  system! "RAILS_ENV=test bin/rails db:schema:load"
+end
+
+puts "\n== Alchemy PgSearch is ready 🎉 =="

--- a/spec/dummy/app/assets/stylesheets/alchemy/admin/custom.css
+++ b/spec/dummy/app/assets/stylesheets/alchemy/admin/custom.css
@@ -1,0 +1,4 @@
+/*
+ * Edit this file to add custom styles to the Alchemy admin interface.
+ * This file will be loaded after the default Alchemy admin stylesheets.
+ */

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,3 +1,10 @@
+development:
+  adapter: postgresql
+  database: alchemy_pg_search_development
+  host: localhost
+  pool: 5
+  timeout: 5000
+
 test:
   adapter: postgresql
   database: alchemy_pg_search_test

--- a/spec/dummy/db/migrate/20260204104123_create_pg_search_documents.rb
+++ b/spec/dummy/db/migrate/20260204104123_create_pg_search_documents.rb
@@ -1,0 +1,17 @@
+class CreatePgSearchDocuments < ActiveRecord::Migration[7.1]
+  def up
+    say_with_time("Creating table for pg_search multisearch") do
+      create_table :pg_search_documents do |t|
+        t.text :content
+        t.belongs_to :searchable, polymorphic: true, index: true
+        t.timestamps null: false
+      end
+    end
+  end
+
+  def down
+    say_with_time("Dropping table for pg_search multisearch") do
+      drop_table :pg_search_documents
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_06_130317) do
+ActiveRecord::Schema[7.1].define(version: 2026_02_04_104766) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -189,6 +189,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_06_130317) do
     t.index ["urlname"], name: "index_pages_on_urlname"
   end
 
+  create_table "alchemy_picture_descriptions", force: :cascade do |t|
+    t.bigint "picture_id", null: false
+    t.bigint "language_id", null: false
+    t.text "text"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["language_id"], name: "index_alchemy_picture_descriptions_on_language_id"
+    t.index ["picture_id", "language_id"], name: "alchemy_picture_descriptions_on_picture_id_and_language_id", unique: true
+    t.index ["picture_id"], name: "index_alchemy_picture_descriptions_on_picture_id"
+  end
+
   create_table "alchemy_picture_thumbs", force: :cascade do |t|
     t.bigint "picture_id", null: false
     t.string "signature", null: false
@@ -277,5 +288,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_06_130317) do
   add_foreign_key "alchemy_page_mutexes", "alchemy_pages", column: "page_id"
   add_foreign_key "alchemy_page_versions", "alchemy_pages", column: "page_id", on_delete: :cascade
   add_foreign_key "alchemy_pages", "alchemy_languages", column: "language_id"
+  add_foreign_key "alchemy_picture_descriptions", "alchemy_languages", column: "language_id"
+  add_foreign_key "alchemy_picture_descriptions", "alchemy_pictures", column: "picture_id"
   add_foreign_key "alchemy_picture_thumbs", "alchemy_pictures", column: "picture_id"
 end


### PR DESCRIPTION
Make it easier to setup up the dummy app on fresh installation with a small bin/setup script. Add also a small section to the README to inform about the usage of bin/setup.