### PR TITLE
Fix not searchable parent pages

### DIFF
--- a/app/extensions/alchemy/search/element_extension.rb
+++ b/app/extensions/alchemy/search/element_extension.rb
@@ -8,11 +8,15 @@ module Alchemy::Search::ElementExtension
   end
 
   def searchable?
-    searchable && public? && page.searchable? && page_version.public?
+    searchable && public? && page.searchable? && page_version.public? && parent_elements_searchable?
   end
 
   def searchable_content
     ingredients.select(&:searchable?).map(&:searchable_content).join(" ").squish
+  end
+
+  def parent_elements_searchable?
+    parent_element.nil? || (parent_element.searchable && parent_element.public? && parent_element.parent_elements_searchable?)
   end
 end
 

--- a/app/extensions/alchemy/search/page_extension.rb
+++ b/app/extensions/alchemy/search/page_extension.rb
@@ -6,7 +6,7 @@ module Alchemy::Search::PageExtension
   end
 
   def searchable_content
-    all_elements.includes(ingredients: {element: :page}).map(&:searchable_content).join(" ")
+    all_elements.includes(:page, :page_version, {parent_element: :parent_element}, ingredients: {element: :page}).map(&:searchable_content).join(" ")
   end
 end
 

--- a/spec/models/element_spec.rb
+++ b/spec/models/element_spec.rb
@@ -66,6 +66,33 @@ RSpec.describe Alchemy::Element do
         is_expected.to be(false)
       end
     end
+
+    context "with unpublished parent element" do
+      let(:page_version) { create(:alchemy_page_version, :published) }
+      let(:parent_element_unpublished) { create(:alchemy_element, page_version: page_version, public_on: nil) }
+      let(:parent_element) { create(:alchemy_element, parent_element: parent_element_unpublished, page_version: page_version) }
+      let(:element) { create(:alchemy_element, parent_element: parent_element, page_version: page_version) }
+
+      it "should not be searchable" do
+        is_expected.to be(false)
+      end
+    end
+
+    context "with not searchable parent element" do
+      let(:page_version) { create(:alchemy_page_version, :published) }
+      let(:parent_element) { create(:alchemy_element, page_version: page_version) }
+      let(:element) { create(:alchemy_element, parent_element: parent_element, page_version: page_version) }
+
+      before do
+        expect(parent_element).to receive(:definition).at_least(:once) do
+          Alchemy::ElementDefinition.new(searchable: false)
+        end
+      end
+
+      it "should not be searchable" do
+        is_expected.to be(false)
+      end
+    end
   end
 
   describe "searchable_content" do


### PR DESCRIPTION
The index could contain elements that are searchable, but had parent elements that are not searchable. It is now testing for that case and also including more models to prevent N+1 queries during the rebuild of the search index.